### PR TITLE
Add Aggregations Pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@zooniverse/grommet-theme": "^2.2.0",
+    "graphql": "^15.3.0",
+    "graphql-request": "^3.1.0",
     "grommet": "^2.15.0",
     "history": "^5.0.0",
     "lodash": "^4.17.20",

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -21,6 +21,7 @@ function findCurrentSrc(locations, index) {
 }
 
 const SubjectViewer = React.forwardRef(function ({
+  aggregationsData,
   imageUrl,
   imageWidth,
   imageHeight,
@@ -77,10 +78,6 @@ const SubjectViewer = React.forwardRef(function ({
     }
   }
   
-  const aggregationsData = [
-    { x : 0, y: 0 }
-  ]
-  
   React.useEffect(() => {
     interactionRef.current && interactionRef.current.addEventListener('wheel', onWheel, { passive: false })
     
@@ -118,6 +115,7 @@ const SubjectViewer = React.forwardRef(function ({
 })
 
 SubjectViewer.propTypes = {
+  aggregationsData: PropTypes.array,
   imageUrl: PropTypes.string,
   imageWidth: PropTypes.number,
   imageHeight: PropTypes.number,
@@ -129,6 +127,7 @@ SubjectViewer.propTypes = {
 }
 
 SubjectViewer.defaultProps = {
+  aggregationsData: [],
   imageUrl: undefined,
   imageWidth: 1,
   imageHeight: 1,

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
+import AggregationsPane from './components/AggregationsPane'
 
 let cursorPos = { x: 0, y: 0 }
 
@@ -76,6 +77,10 @@ const SubjectViewer = React.forwardRef(function ({
     }
   }
   
+  const aggregationsData = [
+    { x : 0, y: 0 }
+  ]
+  
   React.useEffect(() => {
     interactionRef.current && interactionRef.current.addEventListener('wheel', onWheel, { passive: false })
     
@@ -100,6 +105,12 @@ const SubjectViewer = React.forwardRef(function ({
           xlinkHref={imageUrl}
           x={imageWidth * -0.5}
           y={imageHeight * -0.5}
+        />
+        <AggregationsPane
+          data={aggregationsData}
+          offsetX={imageWidth * -0.5}
+          offsetY={imageHeight * -0.5}
+          zoom={zoom}
         />
       </g>
     </SVG>

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -63,6 +63,31 @@ function SubjectViewerContainer() {
   }, [imageObject, src])
   
   if (store.subject.asyncState !== ASYNC_STATES.READY) return null
+  
+  // Extract aggregations
+  // TODO: plenty of improvements can be done here!
+  // ----------------
+  let aggregationsData = []
+  try {
+    const INDEX = 0
+    const PAGE = 0
+    if (
+      store.aggregations.asyncState === ASYNC_STATES.READY
+      && store.aggregations.current && store.aggregations.current.workflow.reductions[INDEX].data
+    ) {
+      const frame = store.aggregations.current.workflow.reductions[INDEX].data[`frame${PAGE}`]
+      const points_x = frame['T0_tool0_points_x'] || []  // TODO: make flexible
+      const points_y = frame['T0_tool0_points_y'] || []
+      
+      for (let i = 0; i < points_x.length && i < points_y.length; i++) {
+        aggregationsData.push({ x: points_x[i], y: points_y[i] })
+      }
+    }
+  } catch (err) {
+    console.warn(err)
+    aggregationsData = []
+  }
+  // ----------------
 
   return (
     <Box
@@ -73,6 +98,7 @@ function SubjectViewerContainer() {
     >
       <SubjectViewer
         ref={containerRef}
+        aggregationsData={aggregationsData}
         imageUrl={src}
         imageWidth={imageWidth}
         imageHeight={imageHeight}

--- a/src/components/SubjectViewer/components/AggregationsPane.js
+++ b/src/components/SubjectViewer/components/AggregationsPane.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const DEFAULT_SIZE = 8
+const STROKE_WIDTH_RATIO = 0.5
+
+const AggregationsPane = function ({
+  data,
+  offsetX,
+  offsetY,
+  zoom,
+}) {
+  const pointSize = 4 / zoom
+  
+  return (
+    <g transform={`translate(${offsetX}, ${offsetY})`}>
+      {data.map((point) => {
+        return (
+          <circle
+            cx={point.x}
+            cx={point.x}
+            r={pointSize}
+            fill="#00979d"
+            stroke="#ffffff"
+            strokeWidth={pointSize * STROKE_WIDTH_RATIO}
+          />
+        )
+      })}
+    </g>
+  )
+}
+
+AggregationsPane.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.object),
+  offsetX: PropTypes.number,
+  offsetY: PropTypes.number,
+  zoom: PropTypes.number,
+}
+
+AggregationsPane.defaultProps = {
+  data: [],
+  offsetX: 0,
+  offsetY: 0,
+  zoom: 1,
+}
+
+export default AggregationsPane

--- a/src/components/SubjectViewer/components/AggregationsPane.js
+++ b/src/components/SubjectViewer/components/AggregationsPane.js
@@ -14,9 +14,10 @@ const AggregationsPane = function ({
   
   return (
     <g transform={`translate(${offsetX}, ${offsetY})`}>
-      {data.map((point) => {
+      {data.map((point, index) => {
         return (
           <circle
+            key={`aggregation-point-${index}`}
             cx={point.x}
             cx={point.x}
             r={pointSize}

--- a/src/components/SubjectViewer/components/AggregationsPane.js
+++ b/src/components/SubjectViewer/components/AggregationsPane.js
@@ -19,7 +19,7 @@ const AggregationsPane = function ({
           <circle
             key={`aggregation-point-${index}`}
             cx={point.x}
-            cx={point.x}
+            cy={point.y}
             r={pointSize}
             fill="#00979d"
             stroke="#ffffff"

--- a/src/pages/ViewPage.js
+++ b/src/pages/ViewPage.js
@@ -14,6 +14,7 @@ function ViewPage ({ match }) {
   React.useEffect(() => {
     store.workflow.fetchWorkflow(workflowId)
     store.subject.fetchSubject(subjectId)
+    store.aggregations.fetchAggregations(workflowId, subjectId)
     
     return () => {}
   }, [workflowId, subjectId, store.workflow, store.subject])

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -1,0 +1,41 @@
+import { flow, types } from 'mobx-state-tree'
+import { request, gql } from 'graphql-request'
+import ASYNC_STATES from 'helpers/asyncStates'
+import { config } from 'config'
+
+const AggregationsStore = types.model('AggregationsStore', {
+  asyncState: types.optional(types.string, ASYNC_STATES.IDLE),
+  current: types.frozen({}),
+  error: types.optional(types.string, ''),
+}).actions(self => ({
+  reset () {
+    self.current = {}
+  },
+  
+  fetchAggregations: flow (function * fetchAggregations (workflowId, subjectId) {
+    self.asyncState = ASYNC_STATES.LOADING
+    try {
+      const query = gql`{
+        workflow(id: 3438) {
+          reductions(subjectId: 133565) {
+            data
+          }
+        }
+      }`
+      
+      yield request(config.caesar, query).then((data) => {
+        console.log('+++ data: ', data)
+      })
+      
+      self.asyncState = ASYNC_STATES.READY
+    } catch (error) {
+      console.error(error)
+      self.error = error.message
+      self.current = undefined
+      self.asyncState = ASYNC_STATES.ERROR
+    }
+  }),
+
+}))
+
+export { AggregationsStore }

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -12,19 +12,23 @@ const AggregationsStore = types.model('AggregationsStore', {
     self.current = {}
   },
   
+  setCurrent (data) {
+    self.current = data
+  },
+  
   fetchAggregations: flow (function * fetchAggregations (workflowId, subjectId) {
     self.asyncState = ASYNC_STATES.LOADING
     try {
       const query = gql`{
-        workflow(id: 3438) {
-          reductions(subjectId: 133565) {
+        workflow(id: ${workflowId}) {
+          reductions(subjectId: ${subjectId}) {
             data
           }
         }
       }`
       
       yield request(config.caesar, query).then((data) => {
-        console.log('+++ data: ', data)
+        self.setCurrent(data)
       })
       
       self.asyncState = ASYNC_STATES.READY

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -1,4 +1,5 @@
 import { flow, types } from 'mobx-state-tree'
+import { AggregationsStore } from './AggregationsStore'
 import { AuthStore } from './AuthStore'
 import { ImageStore } from './ImageStore'
 import { SubjectStore } from './SubjectStore'
@@ -7,6 +8,7 @@ import { WorkflowStore } from './WorkflowStore'
 
 const AppStore = types.model('AppStore', {
   initialised: types.optional(types.boolean, false),
+  aggregations: types.optional(AggregationsStore, () => AggregationsStore.create({})),
   auth: types.optional(AuthStore, () => AuthStore.create({})),
   image: types.optional(ImageStore, () => ImageStore.create({})),
   subject: types.optional(SubjectStore, () => SubjectStore.create({})),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,7 +3133,7 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3372,6 +3372,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-fetch@^3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
 
 cross-spawn@7.0.1:
   version "7.0.1"
@@ -4550,6 +4557,11 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-files@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
+  integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -4811,6 +4823,15 @@ form-data@^2.3.1:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -5054,6 +5075,20 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
+graphql-request@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-3.1.0.tgz#c487488a1aa7b9a0f02335026b4ec897d645f9d4"
+  integrity sha512-Flg2Bd4Ek9BDJ5qacZC/iYuiS3LroHxQTmlUnfqjo/6jKwowY25FVtoLTnssMCBrYspRYEYEIfF1GN8J3/o5JQ==
+  dependencies:
+    cross-fetch "^3.0.5"
+    extract-files "^9.0.0"
+    form-data "^3.0.0"
+
+graphql@^15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
+  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
 
 grommet-icons@^4.2.0:
   version "4.4.0"
@@ -7264,6 +7299,11 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
+
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@0.9.0:
   version "0.9.0"


### PR DESCRIPTION
## PR Overview

This PR adds a system that fetches and displays aggregated annotations for a given Subject.

- Aggregated annotations data is fetched from Caesar via AggregationsStore.
- Aggregated annotations data is displayed on top of the Subject image via AggregationsPane .
- Currently only **point tasks** are properly aggregated.
  - (And even then, the point annotations have to be keyed to task T0, tool 0. See note below.)
- Example (staging): http://localhost:3000/view/workflow/3438/subject/133565 (compare to results at https://caesar-staging.zooniverse.org/workflows/3438/subjects/133565)

⚠️ Please note:
- The method for extracting Aggregations Data from the Caesar results is very very very haphazardously hardcoded and brittle. Any change to the structure of the workflow or Caesar results will pretty much break the Aggregations pane.
- Let's say there's room for improvement here. Note to Shaun: you already pulled the Workflow data, so perhaps create a helper function that compares the Workflow's Tasks to the Aggregations data, and then extract data based on the foreknowledge of how the Tasks _would look like._