### PR TITLE
Add Workflow Observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mobx-react": "^6.3.0",
     "mobx-state-tree": "^3.17.2",
     "panoptes-client": "^3.3.0",
+    "pusher-js": "^7.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import history from './history'
 import MainLayout from './pages/MainLayout'
 import HomePage from './pages/HomePage'
 import SubjectPage from './pages/SubjectPage'
+import WorkflowPage from './pages/WorkflowPage'
 
 /*
 function checkToken(store) {
@@ -47,6 +48,10 @@ function App() {
             <Route
               exact path='/view/workflow/:workflowId/subject/:subjectId'
               component={SubjectPage}
+            />
+            <Route
+              exact path='/view/workflow/:workflowId'
+              component={WorkflowPage}
             />
           </MainLayout>
         </Grommet>

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ import history from './history'
 
 import MainLayout from './pages/MainLayout'
 import HomePage from './pages/HomePage'
-import ViewPage from './pages/ViewPage'
+import SubjectPage from './pages/SubjectPage'
 
 /*
 function checkToken(store) {
@@ -46,7 +46,7 @@ function App() {
             />
             <Route
               exact path='/view/workflow/:workflowId/subject/:subjectId'
-              component={ViewPage}
+              component={SubjectPage}
             />
           </MainLayout>
         </Grommet>

--- a/src/App.js
+++ b/src/App.js
@@ -53,6 +53,10 @@ function App() {
               exact path='/view/workflow/:workflowId'
               component={WorkflowPage}
             />
+            <Route
+              exact path='/view/workflow'
+              component={WorkflowPage}
+            />
           </MainLayout>
         </Grommet>
       </main>

--- a/src/components/SubjectViewer/components/AggregationsPane.js
+++ b/src/components/SubjectViewer/components/AggregationsPane.js
@@ -10,7 +10,7 @@ const AggregationsPane = function ({
   offsetY,
   zoom,
 }) {
-  const pointSize = 4 / zoom
+  const pointSize = DEFAULT_SIZE / zoom
   
   return (
     <g transform={`translate(${offsetX}, ${offsetY})`}>

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -3,12 +3,14 @@ import styled from 'styled-components'
 import { Anchor, Box, Text } from 'grommet'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
-
+import { env } from 'config'
 import Pusher from 'pusher-js';
 
 let pusher = null
 let channel = null
 const ZOONIVERSE_PUSHER_APP_KEY = '79e8e05ea522377ba6db'
+const ZOONIVERSE_PUSHER_CHANNEL = 'panoptes'
+// const ZOONIVERSE_PUSHER_CHANNEL = (env === 'staging') ? 'panoptes-staging' : 'panoptes'
 const MAX_SUBJECTS = 10
 
 const WorkflowObserver = function ({
@@ -42,7 +44,7 @@ const WorkflowObserver = function ({
     if (!pusher) {
       pusher = new Pusher(ZOONIVERSE_PUSHER_APP_KEY)
     }
-    channel = pusher.subscribe('panoptes')
+    channel = pusher.subscribe(ZOONIVERSE_PUSHER_CHANNEL)
     
     channel.bind('classification', handleClassification)
     
@@ -69,6 +71,7 @@ const WorkflowObserver = function ({
 }
 
 WorkflowObserver.propTypes = {
+  workflowId: PropTypes.number,
 }
 
 WorkflowObserver.defaultProps = {

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -26,7 +26,6 @@ const WorkflowObserver = function ({
 }) {
   const [recentSubjects, setRecentSubjects] = React.useState([])
   
-  
   function handleClassification (data) {
     if (!data) return
     
@@ -52,7 +51,13 @@ const WorkflowObserver = function ({
     const recents = recentSubjects.slice()
     const existingIndex = recents.findIndex(subject => subjectId === subject.id)
     if (existingIndex >= 0) recents.splice(existingIndex, 1)
-    recents.unshift({ id: subjectId, preview: previewUrl })
+    
+    recents.unshift({
+      id: subjectId,
+      preview: previewUrl,
+      userId: userId,
+      workflowId: data.workflow_id,
+    })
     
     setRecentSubjects(recents.slice(0, Math.min(recents.length, MAX_SUBJECTS)))
   }
@@ -87,6 +92,9 @@ const WorkflowObserver = function ({
                 <Image src={subject.preview} />
               }
               </Box>
+              {(!workflowId) &&
+                <Text margin={{ vertical: 'none', horizontal: 'small' }}>from workflow {subject.workflowId}</Text>
+              }
             </CardBody>
           </Card>
         </StyledAnchor>

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Box } from 'grommet'
+import { Anchor, Box, Text } from 'grommet'
+import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 import Pusher from 'pusher-js';
@@ -8,18 +9,32 @@ import Pusher from 'pusher-js';
 let pusher = null
 let channel = null
 const ZOONIVERSE_PUSHER_APP_KEY = '79e8e05ea522377ba6db'
+const MAX_SUBJECTS = 10
 
 const WorkflowObserver = function ({
   workflowId
 }) {
+  const [recentSubjects, setRecentSubjects] = React.useState([])
+  
+  
   function handleClassification (data) {
+    console.log('+++ data ', data)
     if (!data) return
     
     // if (data.workflow_id != workflowId) return  // Use loose comparison since we might be dealing with strings or numbers
     
     const subjectId = data.subject_ids && data.subject_ids[0]
+    if (!subjectId) return
     
-    console.log(subjectId)
+    const userId = data.user_id
+    
+    const recents = recentSubjects.slice()
+    const existingIndex = recents.indexOf(subjectId)
+    if (existingIndex >= 0) recents.splice(existingIndex, 1)
+    
+    recents.unshift(subjectId)
+    
+    setRecentSubjects(recents.slice(0, Math.min(recents.length, MAX_SUBJECTS)))
     
   }
   
@@ -37,12 +52,18 @@ const WorkflowObserver = function ({
       pusher.subscribe('panoptes')
     }
   })
-  
-  
 
   return (
     <Box>
-      {workflowId}
+      <ul>
+        {recentSubjects.map(subjectId => (
+          <li key={`subject-${subjectId}`}>
+            <Anchor href={`/view/workflow/${workflowId}/subject/${subjectId}`}>
+              <Text>{subjectId}</Text>
+            </Anchor>
+          </li>
+        ))}
+      </ul>
     </Box>
   )
 }

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Box } from 'grommet'
+import PropTypes from 'prop-types'
+
+import Pusher from 'pusher-js';
+
+let pusher = null
+let channel = null
+const ZOONIVERSE_PUSHER_APP_KEY = '79e8e05ea522377ba6db'
+
+const WorkflowObserver = function ({
+  workflowId
+}) {
+  function handleClassification (data) {
+    if (!data) return
+    
+    // if (data.workflow_id != workflowId) return  // Use loose comparison since we might be dealing with strings or numbers
+    
+    const subjectId = data.subject_ids && data.subject_ids[0]
+    
+    console.log(subjectId)
+    
+  }
+  
+  React.useEffect(() => {
+    if (!pusher) {
+      pusher = new Pusher(ZOONIVERSE_PUSHER_APP_KEY)
+    }
+    channel = pusher.subscribe('panoptes')
+    
+    channel.bind('classification', handleClassification)
+    
+    return () => {
+      channel.unbind()
+      channel = null
+      pusher.subscribe('panoptes')
+    }
+  })
+  
+  
+
+  return (
+    <Box>
+      {workflowId}
+    </Box>
+  )
+}
+
+WorkflowObserver.propTypes = {
+}
+
+WorkflowObserver.defaultProps = {
+}
+
+export default WorkflowObserver

--- a/src/components/WorkflowObserver/index.js
+++ b/src/components/WorkflowObserver/index.js
@@ -1,0 +1,1 @@
+export { default } from './WorkflowObserver'

--- a/src/pages/SubjectPage.js
+++ b/src/pages/SubjectPage.js
@@ -6,7 +6,7 @@ import AppContext from 'stores'
 
 import SubjectViewer from 'components/SubjectViewer'
 
-function ViewPage ({ match }) {
+function SubjectPage ({ match }) {
   const store = React.useContext(AppContext)
   const workflowId = match.params.workflowId
   const subjectId = match.params.subjectId
@@ -32,5 +32,5 @@ function ViewPage ({ match }) {
   )
 }
 
-export { ViewPage }
-export default withRouter(observer(ViewPage))
+export { SubjectPage }
+export default withRouter(observer(SubjectPage))

--- a/src/pages/WorkflowPage.js
+++ b/src/pages/WorkflowPage.js
@@ -4,33 +4,32 @@ import { observer } from 'mobx-react'
 import { withRouter } from 'react-router-dom'
 import AppContext from 'stores'
 
-import SubjectViewer from 'components/SubjectViewer'
+import WorkflowObserver from 'components/WorkflowObserver'
 
-function SubjectPage ({ match }) {
+function WorkflowPage ({ match }) {
   const store = React.useContext(AppContext)
   const workflowId = match.params.workflowId
-  const subjectId = match.params.subjectId
   
   React.useEffect(() => {
     store.workflow.fetchWorkflow(workflowId)
-    store.subject.fetchSubject(subjectId)
-    store.aggregations.fetchAggregations(workflowId, subjectId)
     
     return () => {}
-  }, [workflowId, subjectId, store.workflow, store.subject, store.aggregations])
+  }, [workflowId, store.workflow])
   
   return (
     <Box>
-      <Heading as="h2" size="xsmall">Viewing Subject</Heading>
+      <Heading as="h2" size="xsmall">Preparing Workflow</Heading>
       <Text>
-        Subject: {subjectId} ({store.subject.asyncState})
-        &nbsp;|&nbsp;
         Workflow: {workflowId} ({store.workflow.asyncState}) {store.workflow.current && store.workflow.current.display_name}
       </Text>
-      <SubjectViewer />
+      
+      <WorkflowObserver
+        workflowId={workflowId}
+      />
+      
     </Box>
   )
 }
 
-export { SubjectPage }
-export default withRouter(observer(SubjectPage))
+export { WorkflowPage }
+export default withRouter(observer(WorkflowPage))

--- a/src/pages/WorkflowPage.js
+++ b/src/pages/WorkflowPage.js
@@ -1,10 +1,15 @@
 import React from 'react'
-import { Box, Heading, Text } from 'grommet'
+import { Box, Heading, Paragraph, Text } from 'grommet'
+import styled from 'styled-components'
 import { observer } from 'mobx-react'
 import { withRouter } from 'react-router-dom'
 import AppContext from 'stores'
 
 import WorkflowObserver from 'components/WorkflowObserver'
+
+const StyledParagraph = styled(Paragraph)`
+  max-width: 40rem;
+`
 
 function WorkflowPage ({ match }) {
   const store = React.useContext(AppContext)
@@ -18,11 +23,16 @@ function WorkflowPage ({ match }) {
   
   return (
     <Box>
-      <Heading as="h2" size="xsmall">Preparing Workflow</Heading>
+      <Heading as="h2" size="xsmall">Observing Classifications</Heading>
       {workflowId &&
-        <Text>
-          Workflow: {workflowId} ({store.workflow.asyncState}) {store.workflow.current && store.workflow.current.display_name}
-        </Text>
+        <>
+          <Text>
+            Workflow: {workflowId} ({store.workflow.asyncState}) {store.workflow.current && store.workflow.current.display_name}
+          </Text>
+          <StyledParagraph>
+            This page is now observing workflow {workflowId}, showing recent Classifications for that project. Leave this web page open while you work on the project on another web browser tab/window.
+          </StyledParagraph>
+        </>
       }
       
       <WorkflowObserver

--- a/src/pages/WorkflowPage.js
+++ b/src/pages/WorkflowPage.js
@@ -19,9 +19,11 @@ function WorkflowPage ({ match }) {
   return (
     <Box>
       <Heading as="h2" size="xsmall">Preparing Workflow</Heading>
-      <Text>
-        Workflow: {workflowId} ({store.workflow.asyncState}) {store.workflow.current && store.workflow.current.display_name}
-      </Text>
+      {workflowId &&
+        <Text>
+          Workflow: {workflowId} ({store.workflow.asyncState}) {store.workflow.current && store.workflow.current.display_name}
+        </Text>
+      }
       
       <WorkflowObserver
         workflowId={workflowId}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8877,6 +8877,13 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+pusher-js@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pusher-js/-/pusher-js-7.0.0.tgz#9716ae3f79ca7f87a269764f278a8e14494a4e20"
+  integrity sha512-2ZSw8msMe6EKNTebQSthRInrWUK9bo3zXPmQx0bfeDFJdSnTWUROhdAhmpRQREHzqrL+l4imv/3uwgIQHUO0oQ==
+  dependencies:
+    tweetnacl "^1.0.3"
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -10620,6 +10627,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
## PR Overview

This PR adds a Workflow Observer, which monitors recent Classifications (or rather, Subjects being classified) for a given workflow.

Intended Usage: this allows a user (or a teachers in a classroom) to classify Subjects on one browser tab, then switch to another tab with the Workflow Observer to see the Subject they just classified.

- To observe a specific workflow (e.g. 1234): `https://zoo-notes.zooniverse.org/view/workflow/1234`
- To observe ALL workflows: `https://zoo-notes.zooniverse.org/view/workflow`
- The Workflow Observer uses a Pusher stream.
  - **External Requirement:** the Zooniverse Pusher stream
  - ⚠️ Currently, I'm only able to fetch streams from Panoptes, not Panoptes-staging. I need to check the Zooniverse Pusher account to see if there IS something there.
