### PR TITLE
Update Aggregations and add Viewer Controls 

### DIFF
--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import AggregationsPane from './components/AggregationsPane'
 
 let cursorPos = { x: 0, y: 0 }
 
@@ -21,7 +20,6 @@ function findCurrentSrc(locations, index) {
 }
 
 const SubjectViewer = React.forwardRef(function ({
-  aggregationsData,
   imageUrl,
   imageWidth,
   imageHeight,
@@ -30,6 +28,7 @@ const SubjectViewer = React.forwardRef(function ({
   zoom,
   setPan,
   setZoom,
+  children,
 }, containerRef) {
   if (!imageUrl || imageUrl.length === 0 || !containerRef) return null
 
@@ -103,19 +102,13 @@ const SubjectViewer = React.forwardRef(function ({
           x={imageWidth * -0.5}
           y={imageHeight * -0.5}
         />
-        <AggregationsPane
-          data={aggregationsData}
-          offsetX={imageWidth * -0.5}
-          offsetY={imageHeight * -0.5}
-          zoom={zoom}
-        />
+        {children}
       </g>
     </SVG>
   )
 })
 
 SubjectViewer.propTypes = {
-  aggregationsData: PropTypes.array,
   imageUrl: PropTypes.string,
   imageWidth: PropTypes.number,
   imageHeight: PropTypes.number,
@@ -127,7 +120,6 @@ SubjectViewer.propTypes = {
 }
 
 SubjectViewer.defaultProps = {
-  aggregationsData: [],
   imageUrl: undefined,
   imageWidth: 1,
   imageHeight: 1,

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -4,10 +4,16 @@ import AppContext from 'stores'
 import { observer } from 'mobx-react'
 import ASYNC_STATES from 'helpers/asyncStates'
 import { mergedTheme } from 'theme'
+import styled from 'styled-components'
 
 import SubjectViewer from './SubjectViewer'
 import AggregationsPane from './components/AggregationsPane'
 import ViewerControls from './components/ViewerControls'
+
+const LargeBox = styled(Box)`
+  min-height: 60vh;
+  min-width: 60vw;
+`
 
 function findCurrentSrc(locations, index) {
   if (!locations || locations.length === 0) return '';
@@ -81,7 +87,7 @@ function SubjectViewerContainer() {
       round='xsmall'
       pad='xsmall'
     >
-      <Box
+      <LargeBox
         background={{ color: colors['light-6'] }}
         ref={containerRef}
       >
@@ -119,7 +125,7 @@ function SubjectViewerContainer() {
             />
           }
         </SubjectViewer>
-      </Box>
+      </LargeBox>
       <ViewerControls
         resetView={store.viewer.resetView}
         setPan={store.viewer.setPan}

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -3,8 +3,10 @@ import { Box } from 'grommet'
 import AppContext from 'stores'
 import { observer } from 'mobx-react'
 import ASYNC_STATES from 'helpers/asyncStates'
+import { mergedTheme } from 'theme'
 
 import SubjectViewer from './SubjectViewer'
+import AggregationsPane from './components/AggregationsPane'
 
 function findCurrentSrc(locations, index) {
   if (!locations || locations.length === 0) return '';
@@ -14,6 +16,7 @@ function findCurrentSrc(locations, index) {
 
 function SubjectViewerContainer() {
   const store = React.useContext(AppContext)
+  const colors = mergedTheme.global.colors
   
   const TMP_INDEX = 0
   const src = findCurrentSrc(store.subject.current.locations, TMP_INDEX)
@@ -64,41 +67,24 @@ function SubjectViewerContainer() {
   
   if (store.subject.asyncState !== ASYNC_STATES.READY) return null
   
-  // Extract aggregations
-  // TODO: plenty of improvements can be done here!
-  // ----------------
-  let aggregationsData = []
-  try {
-    const INDEX = 0
-    const PAGE = 0
-    if (
-      store.aggregations.asyncState === ASYNC_STATES.READY
-      && store.aggregations.current && store.aggregations.current.workflow.reductions[INDEX].data
-    ) {
-      const frame = store.aggregations.current.workflow.reductions[INDEX].data[`frame${PAGE}`]
-      const points_x = frame['T0_tool0_points_x'] || []  // TODO: make flexible
-      const points_y = frame['T0_tool0_points_y'] || []
-      
-      for (let i = 0; i < points_x.length && i < points_y.length; i++) {
-        aggregationsData.push({ x: points_x[i], y: points_y[i] })
-      }
-    }
-  } catch (err) {
-    console.warn(err)
-    aggregationsData = []
-  }
-  // ----------------
+  // TMP
+  const reductions = [{ x: 100, y: 100 }]
+  const extracts = [{ x: 95, y: 105 }, { x: 105, y: 95 }]
+  
+  const showReductions = true
+  const showExtracts = true
+  
+  console.log('+++ mergedTheme ', mergedTheme)
 
   return (
     <Box
-      background={{ color: '#858585' }}
+      background={{ color: colors['light-6'] }}
       height='medium'
       round='xsmall'
       ref={containerRef}
     >
       <SubjectViewer
         ref={containerRef}
-        aggregationsData={aggregationsData}
         imageUrl={src}
         imageWidth={imageWidth}
         imageHeight={imageHeight}
@@ -107,7 +93,30 @@ function SubjectViewerContainer() {
         zoom={store.viewer.zoom}
         setPan={store.viewer.setPan}
         setZoom={store.viewer.setZoom}
-      />
+      >
+        {(showExtracts) &&
+          <AggregationsPane
+            fill={colors['accent-3']}
+            offsetX={imageWidth * -0.5}
+            offsetY={imageHeight * -0.5}
+            points={extracts}
+            pointSize={12}
+            stroke={'#ffffff'}
+            zoom={store.viewer.zoom}
+          />
+        }
+        {(showReductions) &&
+          <AggregationsPane
+            fill={colors['accent-4']}
+            offsetX={imageWidth * -0.5}
+            offsetY={imageHeight * -0.5}
+            points={reductions}
+            pointSize={16}
+            stroke={'#ffffff'}
+            zoom={store.viewer.zoom}
+          />
+        }
+      </SubjectViewer>
     </Box>
   )
 }

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -7,6 +7,7 @@ import { mergedTheme } from 'theme'
 
 import SubjectViewer from './SubjectViewer'
 import AggregationsPane from './components/AggregationsPane'
+import ViewerControls from './components/ViewerControls'
 
 function findCurrentSrc(locations, index) {
   if (!locations || locations.length === 0) return '';
@@ -76,45 +77,54 @@ function SubjectViewerContainer() {
   
   return (
     <Box
-      background={{ color: colors['light-6'] }}
-      height='medium'
+      background={{ color: colors['light-1'] }}
       round='xsmall'
-      ref={containerRef}
+      pad='xsmall'
     >
-      <SubjectViewer
+      <Box
+        background={{ color: colors['light-6'] }}
         ref={containerRef}
-        imageUrl={src}
-        imageWidth={imageWidth}
-        imageHeight={imageHeight}
-        panX={store.viewer.panX}
-        panY={store.viewer.panY}
-        zoom={store.viewer.zoom}
+      >
+        <SubjectViewer
+          ref={containerRef}
+          imageUrl={src}
+          imageWidth={imageWidth}
+          imageHeight={imageHeight}
+          panX={store.viewer.panX}
+          panY={store.viewer.panY}
+          zoom={store.viewer.zoom}
+          setPan={store.viewer.setPan}
+          setZoom={store.viewer.setZoom}
+        >
+          {(showExtracts) &&
+            <AggregationsPane
+              fill={colors['accent-3']}
+              offsetX={imageWidth * -0.5}
+              offsetY={imageHeight * -0.5}
+              points={extracts}
+              pointSize={12}
+              stroke={'#ffffff'}
+              zoom={store.viewer.zoom}
+            />
+          }
+          {(showReductions) &&
+            <AggregationsPane
+              fill={colors['accent-4']}
+              offsetX={imageWidth * -0.5}
+              offsetY={imageHeight * -0.5}
+              points={reductions}
+              pointSize={16}
+              stroke={'#ffffff'}
+              zoom={store.viewer.zoom}
+            />
+          }
+        </SubjectViewer>
+      </Box>
+      <ViewerControls
+        resetView={store.viewer.resetView}
         setPan={store.viewer.setPan}
         setZoom={store.viewer.setZoom}
-      >
-        {(showExtracts) &&
-          <AggregationsPane
-            fill={colors['accent-3']}
-            offsetX={imageWidth * -0.5}
-            offsetY={imageHeight * -0.5}
-            points={extracts}
-            pointSize={12}
-            stroke={'#ffffff'}
-            zoom={store.viewer.zoom}
-          />
-        }
-        {(showReductions) &&
-          <AggregationsPane
-            fill={colors['accent-4']}
-            offsetX={imageWidth * -0.5}
-            offsetY={imageHeight * -0.5}
-            points={reductions}
-            pointSize={16}
-            stroke={'#ffffff'}
-            zoom={store.viewer.zoom}
-          />
-        }
-      </SubjectViewer>
+      />
     </Box>
   )
 }

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -68,14 +68,12 @@ function SubjectViewerContainer() {
   if (store.subject.asyncState !== ASYNC_STATES.READY) return null
   
   // TMP
-  const reductions = [{ x: 100, y: 100 }]
-  const extracts = [{ x: 95, y: 105 }, { x: 105, y: 95 }]
+  const reductions = store.aggregations.reductions
+  const extracts = store.aggregations.extracts
   
   const showReductions = true
   const showExtracts = true
   
-  console.log('+++ mergedTheme ', mergedTheme)
-
   return (
     <Box
       background={{ color: colors['light-6'] }}

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -78,8 +78,8 @@ function SubjectViewerContainer() {
   const reductions = store.aggregations.reductions
   const extracts = store.aggregations.extracts
   
-  const showReductions = true
-  const showExtracts = true
+  const showReductions = store.viewer.showReductions
+  const showExtracts = store.viewer.showExtracts
   
   return (
     <Box
@@ -130,6 +130,10 @@ function SubjectViewerContainer() {
         resetView={store.viewer.resetView}
         setPan={store.viewer.setPan}
         setZoom={store.viewer.setZoom}
+        setShowExtracts={store.viewer.setShowExtracts}
+        setShowReductions={store.viewer.setShowReductions}
+        showExtracts={store.viewer.showExtracts}
+        showReductions={store.viewer.showReductions}
       />
     </Box>
   )

--- a/src/components/SubjectViewer/components/AggregationsPane.js
+++ b/src/components/SubjectViewer/components/AggregationsPane.js
@@ -5,24 +5,26 @@ const DEFAULT_SIZE = 8
 const STROKE_WIDTH_RATIO = 0.5
 
 const AggregationsPane = function ({
-  data,
+  fill,
   offsetX,
   offsetY,
+  points,
+  stroke,
   zoom,
 }) {
   const pointSize = DEFAULT_SIZE / zoom
   
   return (
     <g transform={`translate(${offsetX}, ${offsetY})`}>
-      {data.map((point, index) => {
+      {points.map((point, index) => {
         return (
           <circle
             key={`aggregation-point-${index}`}
             cx={point.x}
             cy={point.y}
             r={pointSize}
-            fill="#00979d"
-            stroke="#ffffff"
+            fill={fill}
+            stroke={stroke}
             strokeWidth={pointSize * STROKE_WIDTH_RATIO}
           />
         )
@@ -32,16 +34,20 @@ const AggregationsPane = function ({
 }
 
 AggregationsPane.propTypes = {
-  data: PropTypes.arrayOf(PropTypes.object),
+  fill: PropTypes.string,
   offsetX: PropTypes.number,
   offsetY: PropTypes.number,
+  points: PropTypes.arrayOf(PropTypes.object),
+  stroke: PropTypes.string,
   zoom: PropTypes.number,
 }
 
 AggregationsPane.defaultProps = {
-  data: [],
+  fill: '#00979d',
   offsetX: 0,
   offsetY: 0,
+  points: [],
+  stroke: '#ffffff',
   zoom: 1,
 }
 

--- a/src/components/SubjectViewer/components/AggregationsPane.js
+++ b/src/components/SubjectViewer/components/AggregationsPane.js
@@ -1,18 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const DEFAULT_SIZE = 8
-const STROKE_WIDTH_RATIO = 0.5
+const STROKE_WIDTH_RATIO = 0.1
 
 const AggregationsPane = function ({
   fill,
   offsetX,
   offsetY,
   points,
+  pointSize,
   stroke,
   zoom,
 }) {
-  const pointSize = DEFAULT_SIZE / zoom
+  const scaledSize = pointSize / zoom
   
   return (
     <g transform={`translate(${offsetX}, ${offsetY})`}>
@@ -22,10 +22,10 @@ const AggregationsPane = function ({
             key={`aggregation-point-${index}`}
             cx={point.x}
             cy={point.y}
-            r={pointSize}
+            r={scaledSize / 2}
             fill={fill}
             stroke={stroke}
-            strokeWidth={pointSize * STROKE_WIDTH_RATIO}
+            strokeWidth={scaledSize * STROKE_WIDTH_RATIO}
           />
         )
       })}
@@ -38,6 +38,7 @@ AggregationsPane.propTypes = {
   offsetX: PropTypes.number,
   offsetY: PropTypes.number,
   points: PropTypes.arrayOf(PropTypes.object),
+  pointSize: PropTypes.number,
   stroke: PropTypes.string,
   zoom: PropTypes.number,
 }
@@ -47,6 +48,7 @@ AggregationsPane.defaultProps = {
   offsetX: 0,
   offsetY: 0,
   points: [],
+  pointSize: 16,
   stroke: '#ffffff',
   zoom: 1,
 }

--- a/src/components/SubjectViewer/components/ViewerControls.js
+++ b/src/components/SubjectViewer/components/ViewerControls.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, Box } from 'grommet'
+import { Button, Box, Text } from 'grommet'
 import {
-  EmptyCircle, FormDown, FormNext, FormPrevious, FormUp, ZoomIn, ZoomOut,
+  EmptyCircle, Checkbox, CheckboxSelected, FormDown, FormNext, FormPrevious, FormUp, ZoomIn, ZoomOut,
 } from 'grommet-icons'
 import styled from 'styled-components'
 
@@ -17,6 +17,10 @@ const ViewerControls = function ({
   resetView,
   setPan,
   setZoom,
+  setShowExtracts,
+  setShowReductions,
+  showExtracts,
+  showReductions,
 }) {
   return (
     <Box
@@ -59,6 +63,20 @@ const ViewerControls = function ({
           icon={<FormNext size='small' />}
           onClick={() => { setPan({ x: +PAN_STEP, y: 0 }, true) }}
         />
+        <CompactButton
+          icon={(showExtracts) ? <CheckboxSelected size='small' /> : <Checkbox size='small' />}
+          label={<Text size='small'>Show raw points</Text>}
+          onClick={() => { setShowExtracts(!showExtracts) }}
+          plain={true}
+          margin={{ horizontal: 'xsmall', vertical: 'none' }}
+        />
+        <CompactButton
+          icon={(showReductions) ? <CheckboxSelected size='small' /> : <Checkbox size='small' />}
+          label={<Text size='small'>Show aggregated points</Text>}
+          onClick={() => { setShowReductions(!showReductions) }}
+          plain={true}
+          margin={{ horizontal: 'xsmall', vertical: 'none' }}
+        />
       </Box>
     </Box>
   )
@@ -68,12 +86,20 @@ ViewerControls.propTypes = {
   resetView: PropTypes.func,
   setPan: PropTypes.func,
   setZoom: PropTypes.func,
+  setShowExtracts: PropTypes.func,
+  setShowReductions: PropTypes.func,
+  showExtracts: PropTypes.bool,
+  showReductions: PropTypes.bool,
 }
 
 ViewerControls.defaultProps = {
   resetView: () => {},
   setPan: () => {},
   setZoom: () => {},
+  setShowExtracts: () => {},
+  setShowReductions: () => {},
+  showExtracts: true,
+  showReductions: true,
 }
 
 export default ViewerControls

--- a/src/components/SubjectViewer/components/ViewerControls.js
+++ b/src/components/SubjectViewer/components/ViewerControls.js
@@ -1,9 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Button, Box } from 'grommet'
+import {
+  EmptyCircle, FormDown, FormNext, FormPrevious, FormUp, ZoomIn, ZoomOut,
+} from 'grommet-icons'
+import styled from 'styled-components'
 
 const PAN_STEP = 10
 const ZOOM_STEP = 0.1
+
+const CompactButton = styled(Button)`
+  padding: 10px
+`
 
 const ViewerControls = function ({
   resetView,
@@ -11,10 +19,47 @@ const ViewerControls = function ({
   setZoom,
 }) {
   return (
-    <Box>
-      <Button onClick={() => { setZoom(ZOOM_STEP, true) }}>+</Button>
-      <Button onClick={() => { setZoom(-ZOOM_STEP, true) }}>-</Button>
-      <Button onClick={() => { resetView() }}>Reset</Button>
+    <Box
+      align='center'
+      direction='row'
+      wrap={true}
+    >
+      <CompactButton
+        icon={<ZoomIn size='small' />}
+        onClick={() => { setZoom(ZOOM_STEP, true) }}
+        size='large'
+      />
+      <CompactButton
+        icon={<ZoomOut size='small' />}
+        onClick={() => { setZoom(-ZOOM_STEP, true) }}
+      />
+      <CompactButton
+        icon={<EmptyCircle size='small' />}
+        onClick={() => { resetView() }}
+      />
+      <Box
+        align='center'
+        direction='row'
+      >
+        <CompactButton
+          icon={<FormPrevious size='small' />}
+          onClick={() => { setPan({ x: -PAN_STEP, y: 0 }, true) }}
+        />
+        <Box>
+          <CompactButton
+            icon={<FormUp size='small' />}
+            onClick={() => { setPan({ x: 0, y: -PAN_STEP }, true) }}
+          />
+          <CompactButton
+            icon={<FormDown size='small' />}
+            onClick={() => { setPan({ x: 0, y: +PAN_STEP }, true) }}
+          />  
+        </Box>
+        <CompactButton
+          icon={<FormNext size='small' />}
+          onClick={() => { setPan({ x: +PAN_STEP, y: 0 }, true) }}
+        />
+      </Box>
     </Box>
   )
 }

--- a/src/components/SubjectViewer/components/ViewerControls.js
+++ b/src/components/SubjectViewer/components/ViewerControls.js
@@ -2,9 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Button, Box, Text } from 'grommet'
 import {
-  EmptyCircle, Checkbox, CheckboxSelected, FormDown, FormNext, FormPrevious, FormUp, ZoomIn, ZoomOut,
+  EmptyCircle, FormDown, FormNext, FormPrevious, FormUp, ZoomIn, ZoomOut,
 } from 'grommet-icons'
 import styled from 'styled-components'
+import { mergedTheme } from 'theme'
 
 const PAN_STEP = 10
 const ZOOM_STEP = 0.1
@@ -22,6 +23,10 @@ const ViewerControls = function ({
   showExtracts,
   showReductions,
 }) {
+  const EmptyIcon = <Box round='small' background='light-4' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
+  const ExtractsIcon = <Box round='small' background='accent-3' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
+  const ReductionsIcon = <Box round='small' background='accent-4' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
+  
   return (
     <Box
       align='center'
@@ -64,14 +69,14 @@ const ViewerControls = function ({
           onClick={() => { setPan({ x: +PAN_STEP, y: 0 }, true) }}
         />
         <CompactButton
-          icon={(showExtracts) ? <CheckboxSelected size='small' /> : <Checkbox size='small' />}
+          icon={(showExtracts) ? ExtractsIcon : EmptyIcon}
           label={<Text size='small'>Show raw points</Text>}
           onClick={() => { setShowExtracts(!showExtracts) }}
           plain={true}
           margin={{ horizontal: 'xsmall', vertical: 'none' }}
         />
         <CompactButton
-          icon={(showReductions) ? <CheckboxSelected size='small' /> : <Checkbox size='small' />}
+          icon={(showReductions) ? ReductionsIcon : EmptyIcon}
           label={<Text size='small'>Show aggregated points</Text>}
           onClick={() => { setShowReductions(!showReductions) }}
           plain={true}

--- a/src/components/SubjectViewer/components/ViewerControls.js
+++ b/src/components/SubjectViewer/components/ViewerControls.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, Box } from 'grommet'
+
+const PAN_STEP = 10
+const ZOOM_STEP = 0.1
+
+const ViewerControls = function ({
+  resetView,
+  setPan,
+  setZoom,
+}) {
+  return (
+    <Box>
+      <Button onClick={() => { setZoom(ZOOM_STEP, true) }}>+</Button>
+      <Button onClick={() => { setZoom(-ZOOM_STEP, true) }}>-</Button>
+      <Button onClick={() => { resetView() }}>Reset</Button>
+    </Box>
+  )
+}
+
+ViewerControls.propTypes = {
+  resetView: PropTypes.func,
+  setPan: PropTypes.func,
+  setZoom: PropTypes.func,
+}
+
+ViewerControls.defaultProps = {
+  resetView: () => {},
+  setPan: () => {},
+  setZoom: () => {},
+}
+
+export default ViewerControls

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -48,7 +48,6 @@ const AggregationsStore = types.model('AggregationsStore', {
       }`
       
       yield request(config.caesar, query).then((data) => {
-        console.log('+++ data: ', data)
         self.setCurrent(data)
         self.extractData(0)        
       })

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -24,6 +24,9 @@ const AggregationsStore = types.model('AggregationsStore', {
           reductions(subjectId: ${subjectId}) {
             data
           }
+          extracts(subjectId: ${subjectId}) {
+            data
+          }
         }
       }`
       

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -3,9 +3,16 @@ import { request, gql } from 'graphql-request'
 import ASYNC_STATES from 'helpers/asyncStates'
 import { config } from 'config'
 
+const Point = types.model('Point', {
+  x: types.number,
+  y: types.number,
+})
+
 const AggregationsStore = types.model('AggregationsStore', {
   asyncState: types.optional(types.string, ASYNC_STATES.IDLE),
   current: types.frozen({}),
+  extracts: types.array(Point),
+  reductions: types.array(Point),
   error: types.optional(types.string, ''),
 }).actions(self => ({
   reset () {
@@ -31,6 +38,8 @@ const AggregationsStore = types.model('AggregationsStore', {
       }`
       
       yield request(config.caesar, query).then((data) => {
+        console.log('+++ data: ', data)
+        
         self.setCurrent(data)
       })
       

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -70,7 +70,7 @@ const AggregationsStore = types.model('AggregationsStore', {
       wf.extracts.forEach(classification => {
         const frame = classification.data[`frame${page}`]
         const xs = frame[`${taskId}_tool${toolId}_x`]
-        const ys = frame[`${taskId}_tool${toolId}_x`]
+        const ys = frame[`${taskId}_tool${toolId}_y`]
         
         for (let i = 0; i < xs.length && i < ys.length; i++) {
           extracts.push({
@@ -84,7 +84,7 @@ const AggregationsStore = types.model('AggregationsStore', {
       wf.reductions.forEach(classification => {
         const frame = classification.data[`frame${page}`]
         const xs = frame[`${taskId}_tool${toolId}_points_x`]
-        const ys = frame[`${taskId}_tool${toolId}_points_x`]
+        const ys = frame[`${taskId}_tool${toolId}_points_y`]
         
         for (let i = 0; i < xs.length && i < ys.length; i++) {
           reductions.push({

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -77,10 +77,22 @@ const AggregationsStore = types.model('AggregationsStore', {
             x: xs[i],
             y: ys[i],
           })
-        }        
+        }
       })
       
       const reductions = []
+      wf.reductions.forEach(classification => {
+        const frame = classification.data[`frame${page}`]
+        const xs = frame[`${taskId}_tool${toolId}_points_x`]
+        const ys = frame[`${taskId}_tool${toolId}_points_x`]
+        
+        for (let i = 0; i < xs.length && i < ys.length; i++) {
+          reductions.push({
+            x: xs[i],
+            y: ys[i],
+          })
+        }
+      })
 
       self.setExtracts(extracts)
       self.setReductions(reductions)

--- a/src/stores/ViewerStore.js
+++ b/src/stores/ViewerStore.js
@@ -11,6 +11,8 @@ const ViewerStore = types.model('ViewerStore', {
   viewerHeight: types.optional(types.number, 0),
   panX: types.optional(types.number, 0),
   panY: types.optional(types.number, 0),
+  showExtracts: types.optional(types.boolean, true),
+  showReductions: types.optional(types.boolean, true),
   zoom: types.optional(types.number, 1),
 }).actions(self => ({
   reset () {
@@ -66,6 +68,14 @@ const ViewerStore = types.model('ViewerStore', {
   setViewerSize ({ width, height }) {
     self.viewerWidth = width
     self.viewerHeight = height
+  },
+  
+  setShowExtracts (bool) {
+    self.showExtracts = bool
+  },
+  
+  setShowReductions (bool) {
+    self.showReductions = bool
   },
 }))
 


### PR DESCRIPTION
## PR Overview

This PR updates the aggregations pane and adds controls for the Subject Viewer.

- the Aggregations Store now cleanly separates 'extracts' (raw classifications) and 'reductions' (actual aggregations) into their own arrays
- the Subject Viewer has been updated so it displays two kinds of 'aggregation data' - the extracts and the reductions. Both types of data points have their own colour (and exist on their own AggregationPane component)
- The Subject Viewer now has actual buttons to control panning, zooming, and toggling the visibility of extracts/reductions.