### PR TITLE
Improve UI/UX for website navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -54,7 +54,7 @@ function App() {
               component={WorkflowPage}
             />
             <Route
-              exact path='/view/workflow'
+              exact path='/view'
               component={WorkflowPage}
             />
           </MainLayout>

--- a/src/components/LargeMessageBox/LargeMessageBox.js
+++ b/src/components/LargeMessageBox/LargeMessageBox.js
@@ -17,6 +17,7 @@ const LargeMessageBox = function ({
       justify='center'
       round='xsmall'
       size='medium'
+      pad='small'
     >
       {children}
     </LargeBox>

--- a/src/components/LargeMessageBox/LargeMessageBox.js
+++ b/src/components/LargeMessageBox/LargeMessageBox.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { Box, Text } from 'grommet'
 
 const LargeBox = styled(Box)`
-  min-width: 80%;
+  min-width: 100%;
   min-height: 10em;
 `
 
@@ -15,7 +15,6 @@ const LargeMessageBox = function ({
       background='#e5e5e5'
       align='center'
       justify='center'
-      margin={{ vertical: 'small', horizontal: 'auto', }}
       round='xsmall'
       size='medium'
     >

--- a/src/components/LargeMessageBox/LargeMessageBox.js
+++ b/src/components/LargeMessageBox/LargeMessageBox.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Box, Text } from 'grommet'
+
+const LargeBox = styled(Box)`
+  min-width: 80%;
+  min-height: 10em;
+`
+
+const LargeMessageBox = function ({
+  children
+}) {
+  return (
+    <LargeBox
+      background='#e5e5e5'
+      align='center'
+      justify='center'
+      margin={{ vertical: 'small', horizontal: 'auto', }}
+      round='xsmall'
+      size='medium'
+    >
+      {children}
+    </LargeBox>
+  )
+}
+
+LargeMessageBox.propTypes = {}
+
+LargeMessageBox.defaultProps = {}
+
+export default LargeMessageBox

--- a/src/components/LargeMessageBox/index.js
+++ b/src/components/LargeMessageBox/index.js
@@ -1,0 +1,1 @@
+export { default } from './LargeMessageBox'

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box } from 'grommet'
+import { Box, Text } from 'grommet'
 import AppContext from 'stores'
 import { observer } from 'mobx-react'
 import ASYNC_STATES from 'helpers/asyncStates'
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 import SubjectViewer from './SubjectViewer'
 import AggregationsPane from './components/AggregationsPane'
 import ViewerControls from './components/ViewerControls'
+import LargeMessageBox from 'components/LargeMessageBox'
 
 const LargeBox = styled(Box)`
   min-height: 60vh;
@@ -71,6 +72,17 @@ function SubjectViewerContainer() {
     onLoad()
     
   }, [imageObject, src])
+  
+  
+  if (store.subject.asyncState === ASYNC_STATES.ERROR) {
+    console.log(mergedTheme)
+    return (
+      <LargeMessageBox>
+        <Text>ERROR: Could not fetch Subject.</Text>
+        <Text>{store.subject.error}</Text>
+      </LargeMessageBox>
+    )
+  }
   
   if (store.subject.asyncState !== ASYNC_STATES.READY) return null
   

--- a/src/components/SubjectViewer/components/ViewerControls.js
+++ b/src/components/SubjectViewer/components/ViewerControls.js
@@ -34,15 +34,18 @@ const ViewerControls = function ({
       wrap={true}
     >
       <CompactButton
+        a11yTitle='Zoom In button'
         icon={<ZoomIn size='small' />}
         onClick={() => { setZoom(ZOOM_STEP, true) }}
         size='large'
       />
       <CompactButton
+        a11yTitle='Zoom Out button'
         icon={<ZoomOut size='small' />}
         onClick={() => { setZoom(-ZOOM_STEP, true) }}
       />
       <CompactButton
+        a11yTitle='Reset View button'
         icon={<EmptyCircle size='small' />}
         onClick={() => { resetView() }}
       />
@@ -51,24 +54,29 @@ const ViewerControls = function ({
         direction='row'
       >
         <CompactButton
+          a11yTitle='Pan Left button'
           icon={<FormPrevious size='small' />}
           onClick={() => { setPan({ x: -PAN_STEP, y: 0 }, true) }}
         />
         <Box>
           <CompactButton
+            a11yTitle='Pan Up button'
             icon={<FormUp size='small' />}
             onClick={() => { setPan({ x: 0, y: -PAN_STEP }, true) }}
           />
           <CompactButton
+            a11yTitle='Pan Down button'
             icon={<FormDown size='small' />}
             onClick={() => { setPan({ x: 0, y: +PAN_STEP }, true) }}
           />  
         </Box>
         <CompactButton
+          a11yTitle='Pan Right button'
           icon={<FormNext size='small' />}
           onClick={() => { setPan({ x: +PAN_STEP, y: 0 }, true) }}
         />
         <CompactButton
+          a11yTitle={`Show Extracts button ${(showExtracts) ? '(enabled)' : '(disabled)'}`}
           icon={(showExtracts) ? ExtractsIcon : EmptyIcon}
           label={<Text size='small'>Show raw points</Text>}
           onClick={() => { setShowExtracts(!showExtracts) }}
@@ -76,6 +84,7 @@ const ViewerControls = function ({
           margin={{ horizontal: 'xsmall', vertical: 'none' }}
         />
         <CompactButton
+          a11yTitle={`Show Reductions button ${(showReductions) ? '(enabled)' : '(disabled)'}`}
           icon={(showReductions) ? ReductionsIcon : EmptyIcon}
           label={<Text size='small'>Show aggregated points</Text>}
           onClick={() => { setShowReductions(!showReductions) }}

--- a/src/components/WorkflowInputBox/WorkflowInputBox.js
+++ b/src/components/WorkflowInputBox/WorkflowInputBox.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Box, Button, TextInput } from 'grommet'
+import { FormNext as NextIcon } from 'grommet-icons'
+import PropTypes from 'prop-types'
+
+const WorkflowInputBox = function () {
+  const workflowInput = React.useRef(null)
+  
+  function goToWorkflow () {
+    let value = workflowInput.current && workflowInput.current.value || ''
+    value = value.replace(/\D/g, '')
+    if (value.length > 0) window.location = `/view/workflow/${value}`
+  }
+  
+  return (
+    <Box
+      direction='row'
+      gap='xsmall'
+    >
+      <TextInput
+        pad='xsmall'
+        placeholder="Workflow ID, e.g. '1234'"
+        ref={workflowInput}
+        size='small'
+      />
+      <Button
+        gap='xsmall'
+        icon={<NextIcon size='small' />}
+        label='Go'
+        onClick={goToWorkflow}
+        reverse={true}
+        size='small'
+      />
+    </Box>
+    
+  )
+}
+
+WorkflowInputBox.propTypes = {}
+
+WorkflowInputBox.defaultProps = {}
+
+export default WorkflowInputBox

--- a/src/components/WorkflowInputBox/index.js
+++ b/src/components/WorkflowInputBox/index.js
@@ -1,0 +1,1 @@
+export { default } from './WorkflowInputBox'

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -12,6 +12,11 @@ const StyledAnchor = styled(Anchor)`
   text-decoration: none;
 `
 
+const LargeBox = styled(Box)`
+  min-width: 50%;
+  min-height: 10em;
+`
+
 let pusher = null
 let channel = null
 const ZOONIVERSE_PUSHER_APP_KEY = '79e8e05ea522377ba6db'
@@ -79,6 +84,18 @@ const WorkflowObserver = function ({
 
   return (
     <Box wrap={true} direction="row">
+      {(recentSubjects.length === 0) &&
+        <LargeBox
+          background='#e5e5e5'
+          align='center'
+          justify='center'
+          margin={{ vertical: 'small', horizontal: 'auto', }}
+          round='xsmall'
+          size='medium'
+        >
+          <Text>No Classifications yet.</Text>
+        </LargeBox>
+      }
       {recentSubjects.map((subject, index) => (
         <StyledAnchor
           key={`subject-${subject.id}`}

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -7,14 +7,10 @@ import { env } from 'config'
 import Pusher from 'pusher-js'
 
 import { mergedTheme } from 'theme'
+import LargeMessageBox from 'components/LargeMessageBox'
 
 const StyledAnchor = styled(Anchor)`
   text-decoration: none;
-`
-
-const LargeBox = styled(Box)`
-  min-width: 50%;
-  min-height: 10em;
 `
 
 let pusher = null
@@ -85,16 +81,9 @@ const WorkflowObserver = function ({
   return (
     <Box wrap={true} direction="row">
       {(recentSubjects.length === 0) &&
-        <LargeBox
-          background='#e5e5e5'
-          align='center'
-          justify='center'
-          margin={{ vertical: 'small', horizontal: 'auto', }}
-          round='xsmall'
-          size='medium'
-        >
+        <LargeMessageBox>
           <Text>No Classifications yet.</Text>
-        </LargeBox>
+        </LargeMessageBox>
       }
       {recentSubjects.map((subject, index) => (
         <StyledAnchor

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,17 +1,18 @@
 import React from 'react'
-import { Anchor, Box, Heading, Paragraph } from 'grommet'
-import { observer } from 'mobx-react'
-import { withRouter } from 'react-router-dom'
+import { Anchor, Box, Button, Heading, Paragraph } from 'grommet'
+import { FormNext as NextIcon } from 'grommet-icons'
 import styled from 'styled-components'
-import AppContext from 'stores'
+import WorkflowInputBox from 'components/WorkflowInputBox'
 
 const ConstrainedParagraph = styled(Paragraph)`
-  max-width: 40rem;
+  max-width: 32rem;
+`
+
+const ConstrainedBox = styled(Box)`
+  max-width: 32rem;
 `
 
 function HomePage () {
-  const store = React.useContext(AppContext)
-  
   React.useEffect(() => {
     return () => {}
   })
@@ -19,10 +20,50 @@ function HomePage () {
   return (
     <Box>
       <Heading as="h2" size="xsmall">Welcome to Zoo Notes!</Heading>
-      <ConstrainedParagraph>...</ConstrainedParagraph>
+      <ConstrainedParagraph>
+        This is a tool that lets you observe <b>recently classified Subjects</b> from the <Anchor href='https://www.zooniverse.org' target='_blank'>Zooniverse,</Anchor> and then examine the <b>consensus results</b> based on the answers from multiple volunteers.
+      </ConstrainedParagraph>
+      <ConstrainedParagraph>
+        At the moment we're limited to showing consensus results from <b>Point markings.</b>
+      </ConstrainedParagraph>
+      
+      <Box direction='row'>
+        <Box pad={{ vertical: 'small', horizontal: 'small' }}>
+          <NextIcon />
+        </Box>
+        <Box>
+          <ConstrainedParagraph>
+            If there's a specific Workflow you want to observe, enter its ID below. You'll then be able to see recently-viewed Subjects appear as volunteers submit <b>Classifications</b> on the main Zooniverse website.
+          </ConstrainedParagraph>
+          <ConstrainedBox>
+            <WorkflowInputBox />
+          </ConstrainedBox>
+        </Box>
+      </Box>
+      
+      <Box direction='row'>
+        <Box pad={{ vertical: 'small', horizontal: 'small' }}>
+          <NextIcon />
+        </Box>
+        <Box>
+          <ConstrainedParagraph>
+            If you want to observe EVERY Workflow, click the button below. Good luck, though! This will display a LOT of results VERY quickly, so its practical use is fairly limited. 
+          </ConstrainedParagraph>
+          <ConstrainedBox direction='row'>
+            <Button
+              gap='xsmall'
+              href='/view'
+              label='Observe all Classifications'
+              reverse={true}
+              icon={<NextIcon size='small' />}
+            />
+          </ConstrainedBox>
+        </Box>
+      </Box>
+
     </Box>
   )
 }
 
 export { HomePage }
-export default withRouter(observer(HomePage))
+export default HomePage

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,8 +1,13 @@
 import React from 'react'
-import { Box } from 'grommet'
+import { Anchor, Box, Heading, Paragraph } from 'grommet'
 import { observer } from 'mobx-react'
 import { withRouter } from 'react-router-dom'
+import styled from 'styled-components'
 import AppContext from 'stores'
+
+const ConstrainedParagraph = styled(Paragraph)`
+  max-width: 40rem;
+`
 
 function HomePage () {
   const store = React.useContext(AppContext)
@@ -13,7 +18,8 @@ function HomePage () {
   
   return (
     <Box>
-      <h1>Home</h1>
+      <Heading as="h2" size="xsmall">Welcome to Zoo Notes!</Heading>
+      <ConstrainedParagraph>...</ConstrainedParagraph>
     </Box>
   )
 }

--- a/src/pages/MainLayout.js
+++ b/src/pages/MainLayout.js
@@ -40,7 +40,7 @@ function MainLayout ({ children }) {
             },
             {
               label: 'Observe all Classifications',
-              href: '/view/workflow',
+              href: '/view',
             },
           ]}
         />

--- a/src/pages/MainLayout.js
+++ b/src/pages/MainLayout.js
@@ -51,7 +51,7 @@ function MainLayout ({ children }) {
         { children }
       </Box>
       <Footer direction='column'>
-        <Text>Powered by <Anchor href='https://www.zooniverse.org'>the Zooniverse</Anchor></Text>
+        <Text>Powered by <Anchor href='https://www.zooniverse.org' target='_blank'>the Zooniverse</Anchor></Text>
       </Footer>
     </>
   )

--- a/src/pages/MainLayout.js
+++ b/src/pages/MainLayout.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Anchor, Box, Footer, Header, Heading, Image, Text } from 'grommet'
+import { Anchor, Box, Footer, Header, Heading, Image, Menu, Text } from 'grommet'
+import { Menu as MenuIcon } from 'grommet-icons'
 import { withRouter } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 
@@ -12,24 +13,45 @@ const StyledHeader = styled(Header)`
   color: #fff;
 `
 
+const StyledHeading = styled(Heading)`
+  flex: 1 1 auto;
+`
+
 function MainLayout ({ children }) {
   return (
     <>
-      <StyledHeader pad="1rem" direction="row" justify="stretch">
-        <Box size="xsmall" flex={false} width="2rem" height="2rem">
-          <Image alt="Zooniverse" src={zooniverseLogo} fit="contain" />
-        </Box>
-        <Heading size="small" flex={true} border={true} background="#cce">
+      <StyledHeader pad='1rem' direction='row' justify='stretch'>
+        <Anchor href='/'>
+          <Box size='xsmall' flex={false} width='2rem' height='2rem'>
+            <Image alt='Zooniverse' src={zooniverseLogo} fit='contain' />
+          </Box>
+        </Anchor>
+        <StyledHeading flex='grow' border={true} background='#cce'>
           Zooniverse - Zoo Notes
-        </Heading>
+        </StyledHeading>
+        <Menu
+          a11yTitle='Main Menu button'
+          dropAlign={{ 'top': 'top', 'right': 'right', }}
+          icon={<MenuIcon color='#ffffff' />}
+          items={[
+            {
+              label: 'Home',
+              href: '/',
+            },
+            {
+              label: 'Observe all Classifications',
+              href: '/view/workflow',
+            },
+          ]}
+        />
       </StyledHeader>
       <Box
         pad='small'
       >
         { children }
       </Box>
-      <Footer direction="column">
-        <Text>Powered by <Anchor href="https://www.zooniverse.org">the Zooniverse</Anchor></Text>
+      <Footer direction='column'>
+        <Text>Powered by <Anchor href='https://www.zooniverse.org'>the Zooniverse</Anchor></Text>
       </Footer>
     </>
   )

--- a/src/pages/WorkflowPage.js
+++ b/src/pages/WorkflowPage.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import { Box, Button, Heading, Paragraph, Text, TextInput } from 'grommet'
-import { FormNext as NextIcon } from 'grommet-icons'
 import styled from 'styled-components'
 import { observer } from 'mobx-react'
 import { withRouter } from 'react-router-dom'
 import AppContext from 'stores'
 
 import WorkflowObserver from 'components/WorkflowObserver'
+import WorkflowInputBox from 'components/WorkflowInputBox'
 
 const ConstrainedParagraph = styled(Paragraph)`
   max-width: 40rem;
@@ -19,19 +19,12 @@ const ConstrainedBox = styled(Box)`
 function WorkflowPage ({ match }) {
   const store = React.useContext(AppContext)
   const workflowId = match.params.workflowId
-  const workflowInput = React.useRef(null)
   
   React.useEffect(() => {
     store.workflow.fetchWorkflow(workflowId)
     
     return () => {}
   }, [workflowId, store.workflow])
-  
-  function goToWorkflow () {
-    let value = workflowInput.current && workflowInput.current.value || ''
-    value = value.replace(/\D/g, '')
-    if (value.length > 0) window.location = `/view/workflow/${value}`
-  }
   
   return (
     <Box>
@@ -52,25 +45,8 @@ function WorkflowPage ({ match }) {
           <ConstrainedParagraph>
             This page is showing every classifications from every workflow on the Zooniverse. You can view a specific workflow by entering its ID below:
           </ConstrainedParagraph>
-          <ConstrainedBox
-            align='stretch'
-            direction='row'
-            gap='xsmall'
-          >
-            <TextInput
-              pad='xsmall'
-              placeholder="Workflow ID, e.g. '1234'"
-              ref={workflowInput}
-              size='small'
-            />
-            <Button
-              gap='xsmall'
-              icon={<NextIcon size='small' />}
-              label='Go'
-              onClick={goToWorkflow}
-              reverse={true}
-              size='small'
-            />
+          <ConstrainedBox>
+            <WorkflowInputBox />
           </ConstrainedBox>
         </Box>
       }

--- a/src/pages/WorkflowPage.js
+++ b/src/pages/WorkflowPage.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Box, Heading, Paragraph, Text } from 'grommet'
+import { Box, Button, Heading, Paragraph, Text, TextInput } from 'grommet'
+import { FormNext as NextIcon } from 'grommet-icons'
 import styled from 'styled-components'
 import { observer } from 'mobx-react'
 import { withRouter } from 'react-router-dom'
@@ -7,19 +8,30 @@ import AppContext from 'stores'
 
 import WorkflowObserver from 'components/WorkflowObserver'
 
-const StyledParagraph = styled(Paragraph)`
+const ConstrainedParagraph = styled(Paragraph)`
+  max-width: 40rem;
+`
+
+const ConstrainedBox = styled(Box)`
   max-width: 40rem;
 `
 
 function WorkflowPage ({ match }) {
   const store = React.useContext(AppContext)
   const workflowId = match.params.workflowId
+  const workflowInput = React.useRef(null)
   
   React.useEffect(() => {
     store.workflow.fetchWorkflow(workflowId)
     
     return () => {}
   }, [workflowId, store.workflow])
+  
+  function goToWorkflow () {
+    let value = workflowInput.current && workflowInput.current.value || ''
+    value = value.replace(/\D/g, '')
+    if (value.length > 0) window.location = `/view/workflow/${value}`
+  }
   
   return (
     <Box>
@@ -29,10 +41,38 @@ function WorkflowPage ({ match }) {
           <Text>
             Workflow: {workflowId} ({store.workflow.asyncState}) {store.workflow.current && store.workflow.current.display_name}
           </Text>
-          <StyledParagraph>
+          <ConstrainedParagraph>
             This page is now observing workflow {workflowId}, showing recent Classifications for that project. Leave this web page open while you work on the project on another web browser tab/window.
-          </StyledParagraph>
+          </ConstrainedParagraph>
         </>
+      }
+
+      {!workflowId &&
+        <Box>
+          <ConstrainedParagraph>
+            This page is showing every classifications from every workflow on the Zooniverse. You can view a specific workflow by entering its ID below:
+          </ConstrainedParagraph>
+          <ConstrainedBox
+            align='stretch'
+            direction='row'
+            gap='xsmall'
+          >
+            <TextInput
+              pad='xsmall'
+              placeholder="Workflow ID, e.g. '1234'"
+              ref={workflowInput}
+              size='small'
+            />
+            <Button
+              gap='xsmall'
+              icon={<NextIcon size='small' />}
+              label='Go'
+              onClick={goToWorkflow}
+              reverse={true}
+              size='small'
+            />
+          </ConstrainedBox>
+        </Box>
       }
       
       <WorkflowObserver


### PR DESCRIPTION
## PR Overview

This PR adds a number of UI/UX improvements that's meant to help users navigate the website.

- A home page has been added (path: `/`, of course) with instructions for first-time users.
- A main menu has been added to the header.
- The path to 'observe all workflows' page has changed from `/view/workflow` to `/view`
- Status/Error messages are now added to the Workflow Page and Subject Page.
- [Accessibility] Buttons that rely on images now have alt tags.
