### PR TITLE
Add page selection (for multi-image Subjects)

### DIFF
--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -25,9 +25,9 @@ function findCurrentSrc(locations, index) {
 function SubjectViewerContainer() {
   const store = React.useContext(AppContext)
   const colors = mergedTheme.global.colors
+  const locations = (store.subject.current && store.subject.current.locations) || []
   
-  const TMP_INDEX = 0
-  const src = findCurrentSrc(store.subject.current.locations, TMP_INDEX)
+  const src = findCurrentSrc(locations, store.viewer.page)
   const containerRef = React.useRef(null)
   const [imageObject, setImageObject] = React.useState(new Image())
   const [imageWidth, setImageWidth] = React.useState(0)
@@ -139,8 +139,11 @@ function SubjectViewerContainer() {
         </SubjectViewer>
       </LargeBox>
       <ViewerControls
+        page={store.viewer.page}
+        maxPages={locations.length}
         resetView={store.viewer.resetView}
         setPan={store.viewer.setPan}
+        setPage={store.viewer.setPage}
         setZoom={store.viewer.setZoom}
         setShowExtracts={store.viewer.setShowExtracts}
         setShowReductions={store.viewer.setShowReductions}

--- a/src/components/SubjectViewer/components/ViewerControls.js
+++ b/src/components/SubjectViewer/components/ViewerControls.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, Box, Text } from 'grommet'
+import { Button, Box, Select, Text } from 'grommet'
 import {
   EmptyCircle, FormDown, FormNext, FormPrevious, FormUp, ZoomIn, ZoomOut,
 } from 'grommet-icons'
@@ -14,8 +14,11 @@ const CompactButton = styled(Button)`
 `
 
 const ViewerControls = function ({
+  page,
+  maxPages,
   resetView,
   setPan,
+  setPage,
   setZoom,
   setShowExtracts,
   setShowReductions,
@@ -25,6 +28,9 @@ const ViewerControls = function ({
   const EmptyIcon = <Box round='small' background='light-4' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
   const ExtractsIcon = <Box round='small' background='accent-3' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
   const ReductionsIcon = <Box round='small' background='accent-4' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
+    
+  const pageOptions = []
+  for (let i = 0 ; i < maxPages ; i++) pageOptions.push({ label: `Page ${i+1}`, value: i })
   
   return (
     <Box
@@ -32,22 +38,27 @@ const ViewerControls = function ({
       direction='row'
       wrap={true}
     >
-      <CompactButton
-        a11yTitle='Zoom In button'
-        icon={<ZoomIn size='small' />}
-        onClick={() => { setZoom(ZOOM_STEP, true) }}
-        size='large'
-      />
-      <CompactButton
-        a11yTitle='Zoom Out button'
-        icon={<ZoomOut size='small' />}
-        onClick={() => { setZoom(-ZOOM_STEP, true) }}
-      />
-      <CompactButton
-        a11yTitle='Reset View button'
-        icon={<EmptyCircle size='small' />}
-        onClick={() => { resetView() }}
-      />
+      <Box
+        align='center'
+        direction='row'
+      >
+        <CompactButton
+          a11yTitle='Zoom In button'
+          icon={<ZoomIn size='small' />}
+          onClick={() => { setZoom(ZOOM_STEP, true) }}
+          size='large'
+        />
+        <CompactButton
+          a11yTitle='Zoom Out button'
+          icon={<ZoomOut size='small' />}
+          onClick={() => { setZoom(-ZOOM_STEP, true) }}
+        />
+        <CompactButton
+          a11yTitle='Reset View button'
+          icon={<EmptyCircle size='small' />}
+          onClick={() => { resetView() }}
+        />
+      </Box>
       <Box
         align='center'
         direction='row'
@@ -74,6 +85,11 @@ const ViewerControls = function ({
           icon={<FormNext size='small' />}
           onClick={() => { setPan({ x: +PAN_STEP, y: 0 }, true) }}
         />
+      </Box>
+      <Box
+        align='center'
+        direction='row'
+      >
         <CompactButton
           a11yTitle={`Show Extracts button ${(showExtracts) ? '(enabled)' : '(disabled)'}`}
           icon={(showExtracts) ? ExtractsIcon : EmptyIcon}
@@ -91,13 +107,31 @@ const ViewerControls = function ({
           margin={{ horizontal: 'xsmall', vertical: 'none' }}
         />
       </Box>
+      {(pageOptions.length > 1) &&
+        <Box
+          align='center'
+          direction='row'
+        >
+          <Select
+            labelKey='label'
+            options={pageOptions}
+            onChange={({ option }) => { setPage(option.value) }}
+            size='small'
+            value={pageOptions[page]}
+            valueKey='value'
+          />
+        </Box>
+      }
     </Box>
   )
 }
 
 ViewerControls.propTypes = {
+  page: PropTypes.number,
+  maxPages: PropTypes.number,
   resetView: PropTypes.func,
   setPan: PropTypes.func,
+  setPage: PropTypes.func,
   setZoom: PropTypes.func,
   setShowExtracts: PropTypes.func,
   setShowReductions: PropTypes.func,
@@ -106,8 +140,11 @@ ViewerControls.propTypes = {
 }
 
 ViewerControls.defaultProps = {
+  page: 0,
+  maxPages: 1,
   resetView: () => {},
   setPan: () => {},
+  setPage: () => {},
   setZoom: () => {},
   setShowExtracts: () => {},
   setShowReductions: () => {},


### PR DESCRIPTION
## PR Overview

This PR adds a 'paging' system on the Subject Viewer. This is useful for multi-image Subjects.

- If a Subject has more than 1 image, the Viewer Controls displays a selectable dropdown, starting with "page 1"
- Users can change the 'page' (i.e. change the index of the currently viewed image) by selecting from said dropdown.
- Gods help you in the Subject consists of non-image media, though.

Possible improvements:
- Add a 'loading image...' message to address the times when the Subject Viewer is trying to fetch an image file and is visibly blank.
- Also add an 'ERROR COULD NOT FETCH IMAGE' message.