### PR TITLE
Add memory to Workflow Observer

### DIFF
--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -95,6 +95,7 @@ const WorkflowObserver = function ({
         <StyledAnchor
           key={`subject-${subject.id}`}
           href={`/view/workflow/${(workflowId || subject.workflowId)}/subject/${subject.id}`}
+          target='_blank'
         >
           <Card margin="0.5em">
             <CardHeader margin="0.5em">{subject.id}</CardHeader>

--- a/src/helpers/localStorage.js
+++ b/src/helpers/localStorage.js
@@ -1,0 +1,21 @@
+function saveToLocalStorage (key, dataString) {
+  if (!window.localStorage) return undefined
+  window.localStorage.setItem(key, JSON.stringify(dataString))
+  return true
+}
+
+function loadFromLocalStorage (key) {
+  if (!window.localStorage) return undefined
+  const dataString = window.localStorage.getItem(key)
+  let dataObj = {}
+  
+  try {
+    dataObj = JSON.parse(dataString)
+  } catch (err) {
+    console.error(err)
+  }
+  
+  return dataObj
+}
+
+export { saveToLocalStorage, loadFromLocalStorage }


### PR DESCRIPTION
## PR Overview

This PR updates the Workflow Observer component so it saves recently-classified Subjects to local storage, and loads recently-classified Storage from local storage when the page boots up.

- Additionally, the Workflow Observer now opens Subjects in a new window/tab.