### PR TITLE
Add Aggregation controls

### DIFF
--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -7,6 +7,7 @@ import { mergedTheme } from 'theme'
 import styled from 'styled-components'
 
 import SubjectViewer from './SubjectViewer'
+import AggregationControls from './components/AggregationControls'
 import AggregationsPane from './components/AggregationsPane'
 import ViewerControls from './components/ViewerControls'
 import LargeMessageBox from 'components/LargeMessageBox'
@@ -86,7 +87,6 @@ function SubjectViewerContainer() {
   
   if (store.subject.asyncState !== ASYNC_STATES.READY) return null
   
-  // TMP
   const reductions = store.aggregations.reductions
   const extracts = store.aggregations.extracts
   
@@ -149,6 +149,9 @@ function SubjectViewerContainer() {
         setShowReductions={store.viewer.setShowReductions}
         showExtracts={store.viewer.showExtracts}
         showReductions={store.viewer.showReductions}
+      />
+      <AggregationControls
+        stats={store.aggregations.stats}
       />
     </Box>
   )

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -14,7 +14,7 @@ import LargeMessageBox from 'components/LargeMessageBox'
 
 const LargeBox = styled(Box)`
   min-height: 60vh;
-  min-width: 60vw;
+  flex: 1 1 auto;
 `
 
 function findCurrentSrc(locations, index) {
@@ -93,51 +93,59 @@ function SubjectViewerContainer() {
   const showReductions = store.viewer.showReductions
   const showExtracts = store.viewer.showExtracts
   
+  const workflowTasks = store.workflow.current && store.workflow.current.tasks
+  
   return (
     <Box
       background={{ color: colors['light-1'] }}
       round='xsmall'
       pad='xsmall'
     >
-      <LargeBox
-        background={{ color: colors['light-6'] }}
-        ref={containerRef}
-      >
-        <SubjectViewer
+      <Box direction='row'>
+        <LargeBox
+          background={{ color: colors['light-6'] }}
           ref={containerRef}
-          imageUrl={src}
-          imageWidth={imageWidth}
-          imageHeight={imageHeight}
-          panX={store.viewer.panX}
-          panY={store.viewer.panY}
-          zoom={store.viewer.zoom}
-          setPan={store.viewer.setPan}
-          setZoom={store.viewer.setZoom}
         >
-          {(showExtracts) &&
-            <AggregationsPane
-              fill={colors['accent-3']}
-              offsetX={imageWidth * -0.5}
-              offsetY={imageHeight * -0.5}
-              points={extracts}
-              pointSize={12}
-              stroke={'#ffffff'}
-              zoom={store.viewer.zoom}
-            />
-          }
-          {(showReductions) &&
-            <AggregationsPane
-              fill={colors['accent-4']}
-              offsetX={imageWidth * -0.5}
-              offsetY={imageHeight * -0.5}
-              points={reductions}
-              pointSize={16}
-              stroke={'#ffffff'}
-              zoom={store.viewer.zoom}
-            />
-          }
-        </SubjectViewer>
-      </LargeBox>
+          <SubjectViewer
+            ref={containerRef}
+            imageUrl={src}
+            imageWidth={imageWidth}
+            imageHeight={imageHeight}
+            panX={store.viewer.panX}
+            panY={store.viewer.panY}
+            zoom={store.viewer.zoom}
+            setPan={store.viewer.setPan}
+            setZoom={store.viewer.setZoom}
+          >
+            {(showExtracts) &&
+              <AggregationsPane
+                fill={colors['accent-3']}
+                offsetX={imageWidth * -0.5}
+                offsetY={imageHeight * -0.5}
+                points={extracts}
+                pointSize={12}
+                stroke={'#ffffff'}
+                zoom={store.viewer.zoom}
+              />
+            }
+            {(showReductions) &&
+              <AggregationsPane
+                fill={colors['accent-4']}
+                offsetX={imageWidth * -0.5}
+                offsetY={imageHeight * -0.5}
+                points={reductions}
+                pointSize={16}
+                stroke={'#ffffff'}
+                zoom={store.viewer.zoom}
+              />
+            }
+          </SubjectViewer>
+        </LargeBox>
+        <AggregationControls
+          stats={store.aggregations.stats}
+          workflowTasks={workflowTasks}
+        />
+      </Box>
       <ViewerControls
         page={store.viewer.page}
         maxPages={locations.length}
@@ -149,9 +157,6 @@ function SubjectViewerContainer() {
         setShowReductions={store.viewer.setShowReductions}
         showExtracts={store.viewer.showExtracts}
         showReductions={store.viewer.showReductions}
-      />
-      <AggregationControls
-        stats={store.aggregations.stats}
       />
     </Box>
   )

--- a/src/components/SubjectViewer/components/AggregationControls.js
+++ b/src/components/SubjectViewer/components/AggregationControls.js
@@ -3,14 +3,16 @@ import PropTypes from 'prop-types'
 import { Box, Paragraph } from 'grommet'
 import styled from 'styled-components'
 
+const CompactBox = styled(Box)`
+  max-width: 12em;
+`
+
 const AggregationControls = function ({
   stats,
+  workflowTasks,
 }) {
   if (!stats) return null
   const { numClassifications, numExtractPoints, numReductionPoints } = stats
-  
-  const ExtractsIcon = <Box round='small' background='accent-3' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
-  const ReductionsIcon = <Box round='small' background='accent-4' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
   
   let summary = null
   if (numClassifications >= 0 && numExtractPoints >= 0 && numReductionPoints >= 0) {
@@ -26,18 +28,20 @@ const AggregationControls = function ({
   }
 
   return (
-    <Box>
+    <CompactBox margin={{ horizontal: 'small', vertical: 'none' }} background='#ffffff' pad='xsmall'>
       {summary}
-    </Box>
+    </CompactBox>
   )
 }
 
 AggregationControls.propTypes = {
   stats: PropTypes.object,
+  workflowTasks: PropTypes.object,
 }
 
 AggregationControls.defaultProps = {
   stats: {},
+  workflowTasks: {},
 }
 
 export default AggregationControls

--- a/src/components/SubjectViewer/components/AggregationControls.js
+++ b/src/components/SubjectViewer/components/AggregationControls.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Box, Paragraph } from 'grommet'
+import styled from 'styled-components'
+
+const AggregationControls = function ({
+  stats,
+}) {
+  if (!stats) return null
+  const { numClassifications, numExtractPoints, numReductionPoints } = stats
+  
+  const ExtractsIcon = <Box round='small' background='accent-3' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
+  const ReductionsIcon = <Box round='small' background='accent-4' border={{ color: '#ffffff', size: 'small' }} pad='xxsmall' />
+  
+  let summary = null
+  if (numClassifications >= 0 && numExtractPoints >= 0 && numReductionPoints >= 0) {
+    summary = (
+      <Paragraph>
+        This Subject has <b>{numClassifications}</b> Classifications consisting of <b>{numExtractPoints}</b> raw points (annotations). These raw points have been reduced to <b>{numReductionPoints}</b> aggregated points.
+      </Paragraph>
+    )
+  } else {
+    summary = (
+      <Paragraph>Unfortunately, we have no additional information about this Subject.</Paragraph>
+    )
+  }
+
+  return (
+    <Box>
+      {summary}
+    </Box>
+  )
+}
+
+AggregationControls.propTypes = {
+  stats: PropTypes.object,
+}
+
+AggregationControls.defaultProps = {
+  stats: {},
+}
+
+export default AggregationControls

--- a/src/components/SubjectViewer/components/AggregationControls.js
+++ b/src/components/SubjectViewer/components/AggregationControls.js
@@ -18,7 +18,7 @@ const AggregationControls = function ({
   if (numClassifications >= 0 && numExtractPoints >= 0 && numReductionPoints >= 0) {
     summary = (
       <Paragraph>
-        This Subject has <b>{numClassifications}</b> Classifications consisting of <b>{numExtractPoints}</b> raw points (annotations). These raw points have been reduced to <b>{numReductionPoints}</b> aggregated points.
+        This Subject has <b>{numClassifications}</b> Classification(s) consisting of <b>{numExtractPoints}</b> raw point(s) (annotations). These raw points have been reduced to <b>{numReductionPoints}</b> aggregated point(s).
       </Paragraph>
     )
   } else {

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -105,11 +105,11 @@ const WorkflowObserver = function ({
           Showing <b>{recentSubjects.length}</b> of the most recently classified Subject(s). (Maximum of {MAX_SUBJECTS})
         </Text>
         <Button
-          icon={<ClearIcon size='small' />}
+          icon={<ClearIcon color='light-5' size='small' />}
           gap='xsmall'
-          label='Clear'
+          label={<Text size='xsmall' color='light-5'>Clear</Text>}
           onClick={clearRecentSubjects}
-          secondary={true}
+          plain={true}
           size='small'
         />
       </Box>

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Anchor, Box, Card, CardHeader, CardBody, Image, Text } from 'grommet'
+import { Anchor, Box, Button, Card, CardHeader, CardBody, Image, Text } from 'grommet'
+import { Clear as ClearIcon } from 'grommet-icons'
 import PropTypes from 'prop-types'
 import { config, env } from 'config'
 import Pusher from 'pusher-js'
 
 import LargeMessageBox from 'components/LargeMessageBox'
-import { saveToLocalStorage, loadFromLocalStorage } from 'helpers/localStorage'
+import { saveToLocalStorage, loadFromLocalStorage, deleteFromLocalStorage } from 'helpers/localStorage'
 
 const StyledAnchor = styled(Anchor)`
   text-decoration: none;
@@ -69,6 +70,11 @@ const WorkflowObserver = function ({
     saveToLocalStorage(getKey(workflowId), recents)
   }
   
+  function clearRecentSubjects () {
+    deleteFromLocalStorage(getKey(workflowId))
+    setRecentSubjects([])
+  }
+  
   React.useEffect(() => {
     if (!pusher) {
       pusher = new Pusher(config.pusherAppKey)
@@ -83,36 +89,54 @@ const WorkflowObserver = function ({
       pusher.subscribe('panoptes')
     }
   })
-
+  
+  if (recentSubjects.length === 0) {
+    return (
+      <LargeMessageBox>
+        <Text>No Classifications yet.</Text>
+      </LargeMessageBox>
+    )
+  }
+  
   return (
-    <Box wrap={true} direction="row">
-      {(recentSubjects.length === 0) &&
-        <LargeMessageBox>
-          <Text>No Classifications yet.</Text>
-        </LargeMessageBox>
-      }
-      {recentSubjects.map((subject, index) => (
-        <StyledAnchor
-          key={`subject-${subject.id}`}
-          href={`/view/workflow/${(workflowId || subject.workflowId)}/subject/${subject.id}`}
-          target='_blank'
-        >
-          <Card margin="0.5em">
-            <CardHeader margin="0.5em">{subject.id}</CardHeader>
-            <CardBody background="#e5e5e5">
-              <Box width="200px" height="200px">
-              {subject.preview &&
-                <Image src={subject.preview} />
-              }
-              </Box>
-              {(!workflowId) &&
-                <Text margin={{ vertical: 'none', horizontal: 'small' }}>from workflow {subject.workflowId}</Text>
-              }
-            </CardBody>
-          </Card>
-        </StyledAnchor>
-      ))}
-    </Box>
+    <>
+      <Box direction='row' align='center' pad='small' gap='small'>
+        <Text>
+          Showing <b>{recentSubjects.length}</b> of the most recently classified Subject(s). (Maximum of {MAX_SUBJECTS})
+        </Text>
+        <Button
+          icon={<ClearIcon size='small' />}
+          gap='xsmall'
+          label='Clear'
+          onClick={clearRecentSubjects}
+          secondary={true}
+          size='small'
+        />
+      </Box>
+      <Box wrap={true} direction='row'>
+        {recentSubjects.map((subject, index) => (
+          <StyledAnchor
+            key={`subject-${subject.id}`}
+            href={`/view/workflow/${(workflowId || subject.workflowId)}/subject/${subject.id}`}
+            target='_blank'
+          >
+            <Card margin="0.5em">
+              <CardHeader margin="0.5em">{subject.id}</CardHeader>
+              <CardBody background="#e5e5e5">
+                <Box width="200px" height="200px">
+                {subject.preview &&
+                  <Image src={subject.preview} />
+                }
+                </Box>
+                {(!workflowId) &&
+                  <Text margin={{ vertical: 'none', horizontal: 'small' }}>from workflow {subject.workflowId}</Text>
+                }
+              </CardBody>
+            </Card>
+          </StyledAnchor>
+        ))}
+      </Box>
+    </>
   )
 }
 

--- a/src/helpers/localStorage.js
+++ b/src/helpers/localStorage.js
@@ -18,4 +18,9 @@ function loadFromLocalStorage (key) {
   return dataObj
 }
 
-export { saveToLocalStorage, loadFromLocalStorage }
+function deleteFromLocalStorage (key) {
+  if (!window.localStorage) return undefined
+  window.localStorage.removeItem(key)
+}
+
+export { saveToLocalStorage, loadFromLocalStorage, deleteFromLocalStorage }


### PR DESCRIPTION
## PR Overview

This PR adds the Aggregation Controls panel, to the right-side of the Subject Viewer component.

- At the moment, the Aggregation Controls only displays the summary of the Subject's annotations+aggregations.
- A new 'stats' object has been added to the Aggregations Store for this purpose

Additionally:
- A 'Clear' button has been added to the Workflow Observer, allowing users to reset the list of observed Subjects.