### PR TITLE
Fix "null Classifications" scenario

### DIFF
--- a/src/components/SubjectViewer/components/AggregationControls.js
+++ b/src/components/SubjectViewer/components/AggregationControls.js
@@ -17,9 +17,21 @@ const AggregationControls = function ({
   let summary = null
   if (numClassifications >= 0 && numExtractPoints >= 0 && numReductionPoints >= 0) {
     summary = (
-      <Paragraph>
-        This Subject has <b>{numClassifications}</b> Classification(s) consisting of <b>{numExtractPoints}</b> raw point(s) (annotations). These raw points have been reduced to <b>{numReductionPoints}</b> aggregated point(s).
-      </Paragraph>
+      <>
+        <Paragraph>
+          This Subject has <b>{numClassifications}</b> Classification(s) consisting of <b>{numExtractPoints}</b> raw point(s) (annotations). These raw points have been reduced to <b>{numReductionPoints}</b> aggregated point(s).
+        </Paragraph>
+        {(numClassifications > 0 && numExtractPoints === 0 && numReductionPoints === 0) &&
+          <Paragraph>
+            This may indicate that, according to everyone who has seen this Subject, there's nothing on this specific image that's relevant to the Workflow's question. 
+          </Paragraph>
+        }
+        {(numClassifications === 0) &&
+          <Paragraph>
+            This means nobody has classified this Subject yet.
+          </Paragraph>
+        }
+      </>
     )
   } else {
     summary = (

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -84,6 +84,7 @@ const AggregationsStore = types.model('AggregationsStore', {
       wf.extracts.forEach(classification => {
         numClassifications++
         const frame = classification.data[`frame${page}`]
+        if (!frame) return
         const xs = frame[`${taskId}_tool${toolId}_x`]
         const ys = frame[`${taskId}_tool${toolId}_y`]
         
@@ -98,6 +99,7 @@ const AggregationsStore = types.model('AggregationsStore', {
       const reductions = []
       wf.reductions.forEach(classification => {
         const frame = classification.data[`frame${page}`]
+        if (!frame) return
         const xs = frame[`${taskId}_tool${toolId}_points_x`]
         const ys = frame[`${taskId}_tool${toolId}_points_y`]
         


### PR DESCRIPTION
## PR Overview

This PR fixes an issue when Caesar extracts Classifications that have no annotations (e.g., the Subject has no viruses, so no marks were placed)

- When Caesar extracts a Classification with no annotations, the `.extracts` will record that Classification, but as an empty object (no `frame0` child)
- The AggregationsStore made the mistake of assuming that the `frame0` child object would always exist.
- Simple fix was to add an existence check.