### PR TITLE
Fix incorrect mapping of clusters and reductions

### DIFF
--- a/src/components/SubjectViewer/components/AggregationControls.js
+++ b/src/components/SubjectViewer/components/AggregationControls.js
@@ -26,6 +26,11 @@ const AggregationControls = function ({
             This may indicate that, according to everyone who has seen this Subject, there's nothing on this specific image that's relevant to the Workflow's question. 
           </Paragraph>
         }
+        {(numClassifications > 0 && numExtractPoints > 0 && numReductionPoints === 0) &&
+          <Paragraph>
+            This may indicate that there isn't enough agreement to create a consensus.
+          </Paragraph>
+        }
         {(numClassifications === 0) &&
           <Paragraph>
             This means nobody has classified this Subject yet.

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -85,8 +85,8 @@ const AggregationsStore = types.model('AggregationsStore', {
         numClassifications++
         const frame = classification.data[`frame${page}`]
         if (!frame) return
-        const xs = frame[`${taskId}_tool${toolId}_x`]
-        const ys = frame[`${taskId}_tool${toolId}_y`]
+        const xs = frame[`${taskId}_tool${toolId}_x`] || []
+        const ys = frame[`${taskId}_tool${toolId}_y`] || []
         
         for (let i = 0; i < xs.length && i < ys.length; i++) {
           extracts.push({
@@ -100,8 +100,8 @@ const AggregationsStore = types.model('AggregationsStore', {
       wf.reductions.forEach(classification => {
         const frame = classification.data[`frame${page}`]
         if (!frame) return
-        const xs = frame[`${taskId}_tool${toolId}_clusters_x`]
-        const ys = frame[`${taskId}_tool${toolId}_clusters_y`]
+        const xs = frame[`${taskId}_tool${toolId}_clusters_x`] || []
+        const ys = frame[`${taskId}_tool${toolId}_clusters_y`] || []
         
         for (let i = 0; i < xs.length && i < ys.length; i++) {
           reductions.push({

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -100,8 +100,8 @@ const AggregationsStore = types.model('AggregationsStore', {
       wf.reductions.forEach(classification => {
         const frame = classification.data[`frame${page}`]
         if (!frame) return
-        const xs = frame[`${taskId}_tool${toolId}_points_x`]
-        const ys = frame[`${taskId}_tool${toolId}_points_y`]
+        const xs = frame[`${taskId}_tool${toolId}_clusters_x`]
+        const ys = frame[`${taskId}_tool${toolId}_clusters_y`]
         
         for (let i = 0; i < xs.length && i < ys.length; i++) {
           reductions.push({


### PR DESCRIPTION
## PR Review

This PR fixes a major issue in the Aggregations store: when processing [point-type reductions](https://aggregation-caesar.zooniverse.org/reducers.html#point-reducer-dbscan), the store was reading the _constituent raw points of a potential cluster_ as the aggregated points, instead of reading the _actual cluster points._

This, of course, resulted in the viewer showing an incorrect number of "aggregated points".

Incorrect:
<img width="672" alt="Screen Shot 2020-09-24 at 13 47 36" src="https://user-images.githubusercontent.com/13952701/94148089-14f9e300-fe6e-11ea-9441-a37a09e42bcb.png">
_In this example (pre-fix), 15 raw points map to 15 aggregated points. This doesn't make sense, since the number of aggregated points should be far fewer than the number of raw points._

Correct:
<img width="678" alt="Screen Shot 2020-09-24 at 13 47 28" src="https://user-images.githubusercontent.com/13952701/94148108-19be9700-fe6e-11ea-93db-441621575022.png">
_In this example (post-fix), 15 raw points map to 1 aggregated point. This is because from all the raw input provided, only 1 cluster (consensus of input) can be found._

- The fix: `store.aggregations.reductions` now reads points from the Caesar result's `reductions[N].data.frame0.T0_tool0_clusters_x/y` arrays.
  - Previously, it was pulling data from `reductions[N].data.frame0.T0_tool0_points_x/y` arrays, which list the _constituent raw points_ for that cluster.

Additional tweaks:

- An extra message has been added to the summary screen: if number of raw points > 0 and aggregated points == 0, then the aggregations control panel will say _"This may indicate that there isn't enough agreement to create a consensus."_

Terminology: for Zoo Notes, "raw points" are individual Point-type Marks placed by users when they classify the Subject. "Aggregated points" _should_ be the consensus/aggregated results from Caesar, derived/reduced from the the raw user input.

### Testing

A live example can be viewed here: https://zoo-notes.zooniverse.org/view/workflow/3438/subject/134548?env=staging

- This Subject received classifications from 7 separate anonymous users.
- The Zoo Notes subject viewer's only goal at the moment is to 1. display raw points and 2. display aggregated points on top of a Subject image.
  - Note that for the moment, the tool doesn't do anything with the _constituent raw points that make a cluster._
- To confirm that the displayed visual data (raw points + aggregated points) is legit, you need to check the data from `https://caesar-staging.zooniverse.org/graphql` in the browser's network tab is being read correctly.

### Dev Notes

Additional documentation on the Caesar Point Reducer DBSCAN, which is used for Zoo Notes and its related projects (Science Scribbler for Schools): https://aggregation-caesar.zooniverse.org/reducers.html#point-reducer-dbscan

⚠️ This wasn't caught earlier because I made the mistake of submitting multiple test input on the test project **as the same user** (i.e. `darkeshard`) so clusters weren't forming.

### Status

This update been deployed for fast fixing and to enable testing, but a review with an eye on _Caesar comprehension_ is still much appreciated.