### PR TITLE
Update messaging

### DIFF
--- a/src/components/SubjectViewer/components/AggregationControls.js
+++ b/src/components/SubjectViewer/components/AggregationControls.js
@@ -19,7 +19,6 @@ const AggregationControls = function ({
     summary = (
       <>
         <Paragraph>
-          This Subject has  Classification(s) consisting of  raw point(s) (annotations). These raw points have been reduced to  averaged point(s).
           This image has been classified by <b>{numClassifications}</b> people who have made <b>{numExtractPoints}</b> markings. These raw markings have been combined to make <b>{numReductionPoints}</b> averaged point(s).
         </Paragraph>
         {(numClassifications > 0 && numExtractPoints === 0 && numReductionPoints === 0) &&

--- a/src/components/SubjectViewer/components/AggregationControls.js
+++ b/src/components/SubjectViewer/components/AggregationControls.js
@@ -19,11 +19,12 @@ const AggregationControls = function ({
     summary = (
       <>
         <Paragraph>
-          This Subject has <b>{numClassifications}</b> Classification(s) consisting of <b>{numExtractPoints}</b> raw point(s) (annotations). These raw points have been reduced to <b>{numReductionPoints}</b> aggregated point(s).
+          This Subject has  Classification(s) consisting of  raw point(s) (annotations). These raw points have been reduced to  averaged point(s).
+          This image has been classified by <b>{numClassifications}</b> people who have made <b>{numExtractPoints}</b> markings. These raw markings have been combined to make <b>{numReductionPoints}</b> averaged point(s).
         </Paragraph>
         {(numClassifications > 0 && numExtractPoints === 0 && numReductionPoints === 0) &&
           <Paragraph>
-            This may indicate that, according to everyone who has seen this Subject, there's nothing on this specific image that's relevant to the Workflow's question. 
+            This may indicate that, according to everyone who has seen this Subject, there's nothing relevant on this image that needs to be marked.
           </Paragraph>
         }
         {(numClassifications > 0 && numExtractPoints > 0 && numReductionPoints === 0) &&

--- a/src/components/SubjectViewer/components/ViewerControls.js
+++ b/src/components/SubjectViewer/components/ViewerControls.js
@@ -101,7 +101,7 @@ const ViewerControls = function ({
         <CompactButton
           a11yTitle={`Show Reductions button ${(showReductions) ? '(enabled)' : '(disabled)'}`}
           icon={(showReductions) ? ReductionsIcon : EmptyIcon}
-          label={<Text size='small'>Show aggregated points</Text>}
+          label={<Text size='small'>Show averaged points</Text>}
           onClick={() => { setShowReductions(!showReductions) }}
           plain={true}
           margin={{ horizontal: 'xsmall', vertical: 'none' }}

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -16,8 +16,7 @@ const StyledAnchor = styled(Anchor)`
 let pusher = null
 let channel = null
 const ZOONIVERSE_PUSHER_CHANNEL = 'panoptes'
-// const ZOONIVERSE_PUSHER_CHANNEL = (env === 'staging') ? 'panoptes-staging' : 'panoptes'
-const MAX_SUBJECTS = 20
+const MAX_SUBJECTS = 50
 const STORAGE_KEY_PREFIX = 'observed-subjects'
 
 function getKey (workflowId) {


### PR DESCRIPTION
## PR Overview

This PR updates the messaging for the Aggregation Panel's stats paragraph(s), making the text easier for the intended audience of classroom students.

- On that note, **aggregated Points** have now been renamed to **averaged points**

Additionally:
- The maximum number of observed subjects has been increased to 50.
  - Note that the the maximum number of observed subjects is an artificial cap to prevent too much visual noise. (i.e. at 1000+ Subjects, you can't sensibly sort through them all)
  - It's also
  - Otherwise, this limit should be adjusted according to what the users (teachers + classroom) want, after they have a chance to use Zoo Notes in an actual session.