### PR TITLE
Add Workflow Controls

### DIFF
--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -10,6 +10,7 @@ import SubjectViewer from './SubjectViewer'
 import AggregationControls from './components/AggregationControls'
 import AggregationsPane from './components/AggregationsPane'
 import ViewerControls from './components/ViewerControls'
+import WorkflowControls from './components/WorkflowControls'
 import LargeMessageBox from 'components/LargeMessageBox'
 
 const LargeBox = styled(Box)`
@@ -101,6 +102,17 @@ function SubjectViewerContainer() {
       round='xsmall'
       pad='xsmall'
     >
+      <Box direction='row' pad={{ vertical: 'xsmall' }}>
+        <WorkflowControls
+          setTaskId={store.viewer.setTaskId}
+          taskId={store.viewer.taskId}
+          workflowAsyncState={store.workflow.asyncState}
+          workflowError={store.workflow.error}
+          workflowDisplayName={store.workflow.current && store.workflow.current.display_name}
+          workflowId={store.workflow.current && store.workflow.current.id}
+          workflowTasks={workflowTasks}
+        />
+      </Box>
       <Box direction='row'>
         <LargeBox
           background={{ color: colors['light-6'] }}

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -27,9 +27,9 @@ function findCurrentSrc(locations, index) {
 function SubjectViewerContainer() {
   const store = React.useContext(AppContext)
   const colors = mergedTheme.global.colors
-  const locations = (store.subject.current && store.subject.current.locations) || []
+  const locations = store.subject.locations
   
-  const src = findCurrentSrc(locations, store.viewer.page)
+  const src = findCurrentSrc(locations, store.subject.page)
   const containerRef = React.useRef(null)
   const [imageObject, setImageObject] = React.useState(new Image())
   const [imageWidth, setImageWidth] = React.useState(0)
@@ -159,11 +159,11 @@ function SubjectViewerContainer() {
         />
       </Box>
       <ViewerControls
-        page={store.viewer.page}
+        page={store.subject.page}
         maxPages={locations.length}
         resetView={store.viewer.resetView}
         setPan={store.viewer.setPan}
-        setPage={store.viewer.setPage}
+        setPage={store.subject.setPage}
         setZoom={store.viewer.setZoom}
         setShowExtracts={store.viewer.setShowExtracts}
         setShowReductions={store.viewer.setShowReductions}

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -104,8 +104,8 @@ function SubjectViewerContainer() {
     >
       <Box direction='row' pad={{ vertical: 'xsmall' }}>
         <WorkflowControls
-          setTaskId={store.viewer.setTaskId}
-          taskId={store.viewer.taskId}
+          setTaskId={store.workflow.setTaskId}
+          taskId={store.workflow.taskId}
           workflowAsyncState={store.workflow.asyncState}
           workflowError={store.workflow.error}
           workflowDisplayName={store.workflow.current && store.workflow.current.display_name}

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -88,13 +88,14 @@ function SubjectViewerContainer() {
   
   if (store.subject.asyncState !== ASYNC_STATES.READY) return null
   
+  const selectedTask = store.workflow.selectedTask
+  const selectedTaskType = store.workflow.selectedTaskType
+  
   const reductions = store.aggregations.reductions
   const extracts = store.aggregations.extracts
   
   const showReductions = store.viewer.showReductions
   const showExtracts = store.viewer.showExtracts
-  
-  const workflowTasks = store.workflow.current && store.workflow.current.tasks
   
   return (
     <Box
@@ -110,7 +111,7 @@ function SubjectViewerContainer() {
           workflowError={store.workflow.error}
           workflowDisplayName={store.workflow.current && store.workflow.current.display_name}
           workflowId={store.workflow.current && store.workflow.current.id}
-          workflowTasks={workflowTasks}
+          workflowTasks={store.workflow.tasks}
         />
       </Box>
       <Box direction='row'>
@@ -154,8 +155,10 @@ function SubjectViewerContainer() {
           </SubjectViewer>
         </LargeBox>
         <AggregationControls
+          selectedTask={selectedTask}
+          selectedTaskType={selectedTaskType}
           stats={store.aggregations.stats}
-          workflowTasks={workflowTasks}
+          workflowTasks={store.workflow.tasks}
         />
       </Box>
       <ViewerControls

--- a/src/components/SubjectViewer/components/AggregationControls.js
+++ b/src/components/SubjectViewer/components/AggregationControls.js
@@ -8,15 +8,23 @@ const CompactBox = styled(Box)`
 `
 
 const AggregationControls = function ({
+  selectedTask,
+  selectedTaskType,
   stats,
   workflowTasks,
 }) {
   if (!stats) return null
   const { numClassifications, numExtractPoints, numReductionPoints } = stats
   
-  let summary = null
+  let summaryA = null
+  
+  if (selectedTaskType === 'drawing') {
+    summaryA = <Paragraph>We are currently examining the results for a Drawing-type task.</Paragraph>
+  }
+  
+  let summaryB = null
   if (numClassifications >= 0 && numExtractPoints >= 0 && numReductionPoints >= 0) {
-    summary = (
+    summaryB = (
       <>
         <Paragraph>
           This image has been classified by <b>{numClassifications}</b> people who have made <b>{numExtractPoints}</b> markings. These raw markings have been combined to make <b>{numReductionPoints}</b> averaged point(s).
@@ -39,24 +47,29 @@ const AggregationControls = function ({
       </>
     )
   } else {
-    summary = (
+    summaryB = (
       <Paragraph>Unfortunately, we have no additional information about this Subject.</Paragraph>
     )
   }
 
   return (
     <CompactBox margin={{ horizontal: 'small', vertical: 'none' }} background='#ffffff' pad='xsmall'>
-      {summary}
+      {summaryA}
+      {summaryB}
     </CompactBox>
   )
 }
 
 AggregationControls.propTypes = {
+  selectedTask: PropTypes.object,
+  selectedTaskType: PropTypes.string,
   stats: PropTypes.object,
   workflowTasks: PropTypes.object,
 }
 
 AggregationControls.defaultProps = {
+  selectedTask: {},
+  selectedTaskType: '',
   stats: {},
   workflowTasks: {},
 }

--- a/src/components/SubjectViewer/components/WorkflowControls.js
+++ b/src/components/SubjectViewer/components/WorkflowControls.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Box, Select, Text } from 'grommet'
+import styled from 'styled-components'
+
+const WorkflowControls = function ({
+  setTaskId,
+  taskId,
+  workflowAsyncState,
+  workflowError,
+  workflowDisplayName,
+  workflowId,
+  workflowTasks,
+}) {
+  const taskOptions = Object.keys(workflowTasks).map(key => {
+    const task = workflowTasks[key]
+    return {
+      label: `Task ${key}: ${task.instruction}`,
+      value: key,
+    }
+  })
+  const taskValue = taskOptions.find(task => task.value === taskId)
+  
+  return (
+    <Box
+      align='center'
+      direction='row'
+      gap='xsmall'
+      wrap={true}
+    >
+      <Text>
+        Workflow: {workflowId} ({workflowAsyncState}) {workflowDisplayName}
+      </Text>
+      <Select
+        labelKey='label'
+        options={taskOptions}
+        onChange={({ option }) => { setTaskId(option.value) }}
+        size='small'
+        value={taskValue}
+        valueKey='value'
+      />
+    </Box>
+  )
+}
+
+WorkflowControls.propTypes = {
+  setTaskId: PropTypes.func,
+  taskId: PropTypes.string,
+  workflowAsyncState: PropTypes.string,
+  workflowError: PropTypes.string,
+  workflowDisplayName: PropTypes.string,
+  workflowId: PropTypes.string,
+  workflowTasks: PropTypes.object,
+}
+
+WorkflowControls.defaultProps = {
+  setTaskId: () => {},
+  taskId: '',
+  workflowAsyncState: '',
+  workflowError: '',
+  workflowDisplayName: '',
+  workflowId: '',
+  workflowTasks: {},
+}
+
+export default WorkflowControls

--- a/src/stores/SubjectStore.js
+++ b/src/stores/SubjectStore.js
@@ -40,6 +40,8 @@ const SubjectStore = types.model('SubjectStore', {
         self.error = ''
       }
       self.asyncState = ASYNC_STATES.READY
+      
+      // Set initial page
       self.reset()
     } catch (error) {
       console.error(error)

--- a/src/stores/SubjectStore.js
+++ b/src/stores/SubjectStore.js
@@ -12,7 +12,20 @@ const SubjectStore = types.model('SubjectStore', {
   asyncState: types.optional(types.string, ASYNC_STATES.IDLE),
   current: types.optional(Subject, {}),
   error: types.optional(types.string, ''),
-}).actions(self => ({
+  page: types.optional(types.number, 0),  // Currently selected 'frame' of the Subject
+}).views(self => ({
+  get locations () {
+    return (self.current && self.current.locations) || []
+  }
+})).actions(self => ({
+  reset () {
+    self.page = 0
+  },
+  
+  setPage (page) {
+    self.page = page
+  },
+  
   fetchSubject: flow (function * fetchSubject (id) {
     self.asyncState = ASYNC_STATES.LOADING
     try {
@@ -27,6 +40,7 @@ const SubjectStore = types.model('SubjectStore', {
         self.error = ''
       }
       self.asyncState = ASYNC_STATES.READY
+      self.reset()
     } catch (error) {
       console.error(error)
       self.error = error.message

--- a/src/stores/ViewerStore.js
+++ b/src/stores/ViewerStore.js
@@ -4,7 +4,6 @@ const MIN_ZOOM = 0.2
 const MAX_ZOOM = 5.0
 
 const ViewerStore = types.model('ViewerStore', {
-  taskId: types.optional(types.string, ''), // Currently selected Task ID of the Workflow
   imageWidth: types.optional(types.number, 0),
   imageHeight: types.optional(types.number, 0),
   viewerWidth: types.optional(types.number, 0),
@@ -16,7 +15,6 @@ const ViewerStore = types.model('ViewerStore', {
   zoom: types.optional(types.number, 1),
 }).actions(self => ({
   reset () {
-    self.taskId = ''
     self.panX = 0
     self.panY = 0
     self.zoom = 1
@@ -54,10 +52,6 @@ const ViewerStore = types.model('ViewerStore', {
       newZoom = zoom
     }
     self.zoom = Math.max(Math.min(newZoom, MAX_ZOOM), MIN_ZOOM)
-  },
-  
-  setTaskId (taskId) {
-    self.taskId = taskId
   },
   
   setImageSize ({ width, height }) {

--- a/src/stores/ViewerStore.js
+++ b/src/stores/ViewerStore.js
@@ -4,7 +4,6 @@ const MIN_ZOOM = 0.2
 const MAX_ZOOM = 5.0
 
 const ViewerStore = types.model('ViewerStore', {
-  page: types.optional(types.number, 0),  // Currently selected 'frame' of the Subject
   taskId: types.optional(types.string, ''), // Currently selected Task ID of the Workflow
   imageWidth: types.optional(types.number, 0),
   imageHeight: types.optional(types.number, 0),
@@ -17,7 +16,6 @@ const ViewerStore = types.model('ViewerStore', {
   zoom: types.optional(types.number, 1),
 }).actions(self => ({
   reset () {
-    self.page = 0
     self.taskId = ''
     self.panX = 0
     self.panY = 0
@@ -56,10 +54,6 @@ const ViewerStore = types.model('ViewerStore', {
       newZoom = zoom
     }
     self.zoom = Math.max(Math.min(newZoom, MAX_ZOOM), MIN_ZOOM)
-  },
-                    
-  setPage (page) {
-    self.page = page
   },
   
   setTaskId (taskId) {

--- a/src/stores/ViewerStore.js
+++ b/src/stores/ViewerStore.js
@@ -4,7 +4,8 @@ const MIN_ZOOM = 0.2
 const MAX_ZOOM = 5.0
 
 const ViewerStore = types.model('ViewerStore', {
-  page: types.optional(types.number, 0),
+  page: types.optional(types.number, 0),  // Currently selected 'frame' of the Subject
+  taskId: types.optional(types.string, ''), // Currently selected Task ID of the Workflow
   imageWidth: types.optional(types.number, 0),
   imageHeight: types.optional(types.number, 0),
   viewerWidth: types.optional(types.number, 0),
@@ -17,6 +18,7 @@ const ViewerStore = types.model('ViewerStore', {
 }).actions(self => ({
   reset () {
     self.page = 0
+    self.taskId = ''
     self.panX = 0
     self.panY = 0
     self.zoom = 1
@@ -58,6 +60,10 @@ const ViewerStore = types.model('ViewerStore', {
                     
   setPage (page) {
     self.page = page
+  },
+  
+  setTaskId (taskId) {
+    self.taskId = taskId
   },
   
   setImageSize ({ width, height }) {

--- a/src/stores/WorkflowStore.js
+++ b/src/stores/WorkflowStore.js
@@ -1,4 +1,4 @@
-import { flow, types, getRoot } from 'mobx-state-tree'
+import { flow, types } from 'mobx-state-tree'
 import apiClient from 'panoptes-client/lib/api-client.js'
 import ASYNC_STATES from 'helpers/asyncStates'
 
@@ -13,9 +13,17 @@ const WorkflowStore = types.model('WorkflowStore', {
   asyncState: types.optional(types.string, ASYNC_STATES.IDLE),
   current: types.optional(Workflow, {}),
   error: types.optional(types.string, ''),
+  taskId: types.optional(types.string, ''), // Currently selected Task ID of the Workflow
 }).actions(self => ({
+  reset () {
+    self.taskId = ''
+  },
+  
+  setTaskId (taskId) {
+    self.taskId = taskId
+  },
+  
   fetchWorkflow: flow (function * fetchWorkflow (id) {
-    const store = getRoot(self)
     self.asyncState = ASYNC_STATES.LOADING
     try {
       const [workflow] = yield apiClient.type('workflows').get({ id })
@@ -30,7 +38,7 @@ const WorkflowStore = types.model('WorkflowStore', {
         self.error = ''
         
         // Set the initial task
-        store.viewer.setTaskId(workflow.first_task || '')
+        self.setTaskId(workflow.first_task || '')
       }
       self.asyncState = ASYNC_STATES.READY
     } catch (error) {

--- a/src/stores/WorkflowStore.js
+++ b/src/stores/WorkflowStore.js
@@ -14,7 +14,19 @@ const WorkflowStore = types.model('WorkflowStore', {
   current: types.optional(Workflow, {}),
   error: types.optional(types.string, ''),
   taskId: types.optional(types.string, ''), // Currently selected Task ID of the Workflow
-}).actions(self => ({
+}).views(self => ({
+  get tasks () {
+    return (self.current && self.current.tasks) || {}
+  },
+  
+  get selectedTask () {
+    return (self.current && self.current.tasks && self.current.tasks[self.taskId]) || {}
+  },
+  
+  get selectedTaskType () {
+    return self.selectedTask.type
+  },
+})).actions(self => ({
   reset () {
     self.taskId = ''
   },

--- a/src/stores/WorkflowStore.js
+++ b/src/stores/WorkflowStore.js
@@ -1,4 +1,4 @@
-import { flow, types } from 'mobx-state-tree'
+import { flow, types, getRoot } from 'mobx-state-tree'
 import apiClient from 'panoptes-client/lib/api-client.js'
 import ASYNC_STATES from 'helpers/asyncStates'
 
@@ -15,6 +15,7 @@ const WorkflowStore = types.model('WorkflowStore', {
   error: types.optional(types.string, ''),
 }).actions(self => ({
   fetchWorkflow: flow (function * fetchWorkflow (id) {
+    const store = getRoot(self)
     self.asyncState = ASYNC_STATES.LOADING
     try {
       const [workflow] = yield apiClient.type('workflows').get({ id })
@@ -27,6 +28,9 @@ const WorkflowStore = types.model('WorkflowStore', {
         })
         self.current = newWorkflow
         self.error = ''
+        
+        // Set the initial task
+        store.viewer.setTaskId(workflow.first_task || '')
       }
       self.asyncState = ASYNC_STATES.READY
     } catch (error) {


### PR DESCRIPTION
## PR Overview

Currently, the Zoo Notes Subject Viewer system (and the relevant data stores) makes one huge assumption: the selected Workflow will have exactly one Task, and that Task will be a Drawing Task with exactly 1 Point-type subtask.

This PR attempts to expand the scope of what the Subject Viewer can handle, first by allowing users to select which Task they want.

- A new Workflow Controls component has been added to the Subject Viewer, which allows users to switch between Workflow Tasks
- The Workflow Store now keeps track of `workflow.taskId`, which defines the ID of the currently selected Workflow Task.
- The Workflow Store now has methods for easily determining the currently selected Task's data and type.

Misc:
- The `viewer.page` property of the Viewer store - which keeps track of the currently selected Subject frame/page - is now part of the Subject store, i.e. `subject.page`.

Planned:
- The Subject Viewer must react accordingly to different task types
- I need to create a Subject Controls component (to complement Workflow Controls), and then move the 'page selector' feature (currently in Viewer Controls) to that component.

### Status

Ready!