### PR TITLE
Single Answer Question Task starts with expanded view

### DIFF
--- a/src/components/AggregationsViewer/AggregationsViewer.js
+++ b/src/components/AggregationsViewer/AggregationsViewer.js
@@ -29,6 +29,17 @@ function AggregationsViewer () {
   const colors = mergedTheme.global.colors
   const [expand, setExpand] = React.useState(false)
   
+  const selectedTask = store.workflow.selectedTask
+  const selectedTaskType = store.workflow.selectedTaskType
+  const selectedTaskIndex = store.workflow.selectedTaskIndex
+  const stats = store.aggregations.stats
+  const aggregationData = store.aggregations.current && store.aggregations.current.workflow
+  
+  // Is the selected task best seen in an expanded view?
+  React.useEffect(() => {
+    if (selectedTaskType === 'single') setExpand(true)
+  }, [selectedTaskType])  // Only listen when selectedTaskType changes.
+  
   if (store.workflow.asyncState === ASYNC_STATES.ERROR || store.aggregations.asyncState === ASYNC_STATES.ERROR) {
     return (
       <LargeMessageBox wide={false}>
@@ -57,11 +68,6 @@ function AggregationsViewer () {
   }
 
   let AggregationType = null
-  const selectedTask = store.workflow.selectedTask
-  const selectedTaskType = store.workflow.selectedTaskType
-  const selectedTaskIndex = store.workflow.selectedTaskIndex
-  const stats = store.aggregations.stats
-  const aggregationData = store.aggregations.current && store.aggregations.current.workflow
   
   switch (selectedTaskType) {
     case 'drawing':


### PR DESCRIPTION
## PR Overview

This is a minor update that ensures that when the selected Task is of type 'single', the Aggregations Viewer starts off in the expanded view.

- Note the way the React useEffect hook is structured; the 'start with expanded view' will trigger when either...
  - The Aggregation Viewer initialises and the Workflow resource loads. (selectedTaskType changes from 'undefined' to 'single'), or
  - The selected Task changes from a non-SAQ Task to an SAQ Task. (e.g. selectedTaskType changes from 'drawing' to 'single')