### PR TITLE
Pie Charts and various SingleTask improvements

### DIFF
--- a/src/components/AggregationsViewer/components/PieChart.js
+++ b/src/components/AggregationsViewer/components/PieChart.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+
+let cursorPos = { x: 0, y: 0 }
+
+const SVG = styled.svg`
+  max-height: 50vh;
+`
+
+const PieChart = function ({
+  data,
+  maxCount,
+}) {
+  if (maxCount <= 0 || !data || data.length === 0) return null
+  
+  return (
+    <SVG viewBox='-120 -120 240 240'>
+      <circle r='100' cx='0' cy='0' fill='#666666' />
+      <path d={`M 0 0 L 100 0 A 100 100 0 0 1 0 100 Z`} fill='#cc4444' />
+    </SVG>
+  )
+}
+
+PieChart.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    count: PropTypes.number,
+  })),
+  maxCount: PropTypes.number,
+}
+
+PieChart.defaultProps = {
+  data: [],
+  maxCount: 0,
+}
+
+export default PieChart

--- a/src/components/AggregationsViewer/components/PieChart.js
+++ b/src/components/AggregationsViewer/components/PieChart.js
@@ -8,15 +8,19 @@ const SVG = styled.svg`
   max-height: 50vh;
 `
 
+const R = 100
+
 const PieChart = function ({
   data,
-  maxCount,
+  totalCount,
 }) {
-  if (maxCount <= 0 || !data || data.length === 0) return null
+  if (totalCount <= 0 || !data || data.length === 0) return null
+  
+  const percent = data[0]
   
   return (
-    <SVG viewBox='-120 -120 240 240'>
-      <circle r='100' cx='0' cy='0' fill='#666666' />
+    <SVG viewBox={`${R*-1.2} ${R*-1.2} ${R*2.4} ${R*2.4}`}>
+      <circle r={R} cx='0' cy='0' fill='#666666' />
       <path d={`M 0 0 L 100 0 A 100 100 0 0 1 0 100 Z`} fill='#cc4444' />
     </SVG>
   )
@@ -27,12 +31,12 @@ PieChart.propTypes = {
     label: PropTypes.string,
     count: PropTypes.number,
   })),
-  maxCount: PropTypes.number,
+  totalCount: PropTypes.number,
 }
 
 PieChart.defaultProps = {
   data: [],
-  maxCount: 0,
+  totalCount: 0,
 }
 
 export default PieChart

--- a/src/components/AggregationsViewer/components/PieChart.js
+++ b/src/components/AggregationsViewer/components/PieChart.js
@@ -9,6 +9,7 @@ const SVG = styled.svg`
 `
 
 const R = 100
+const MIN_ANGLE_TO_SHOW_COUNT = (30 / 360) * 2 * Math.PI
 
 const PieChart = function ({
   colours,
@@ -27,6 +28,7 @@ const PieChart = function ({
           
           const angle = dataItem.count / totalCount * 2 * Math.PI
           const startAngle = totalAngle
+          const midAngle = startAngle + angle / 2
           const endAngle = startAngle + angle
           const largeArcFlag = (angle > Math.PI) ? 1 : 0
           const sweepFlag = 1  // Clockwise sweep!
@@ -36,12 +38,25 @@ const PieChart = function ({
           if (dataItem.count <= 0) return null
           
           return (
-            <path
-              key={`pie-slice-${index}`}
-              d={`M 0 0 L ${Math.cos(startAngle)*R} ${Math.sin(startAngle)*R} A ${R} ${R} 0 ${largeArcFlag} ${sweepFlag} ${Math.cos(endAngle)*R} ${Math.sin(endAngle)*R} Z`}
-              fill={(colours && colours[index]) || '#666666'}
-              stroke='#ffffff'
-            />
+            <g key={`pie-slice-${index}`}>
+              <path
+                d={`M 0 0 L ${Math.cos(startAngle)*R} ${Math.sin(startAngle)*R} A ${R} ${R} 0 ${largeArcFlag} ${sweepFlag} ${Math.cos(endAngle)*R} ${Math.sin(endAngle)*R} Z`}
+                fill={(colours && colours[index]) || '#666666'}
+                stroke='#ffffff'
+              />
+              {(angle > MIN_ANGLE_TO_SHOW_COUNT) && (
+                <text
+                  alignmentBaseline='middle'
+                  fill='#ffffff'
+                  fontSize='0.5em'
+                  textAnchor='middle'
+                  x={Math.cos(midAngle)*R/2}
+                  y={Math.sin(midAngle)*R/2}
+                >
+                  {'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[index]}: {(dataItem.count / totalCount * 100).toFixed(1)}%
+                </text>
+              )}
+            </g>
           )
         })}
       </g>

--- a/src/components/AggregationsViewer/components/PieChart.js
+++ b/src/components/AggregationsViewer/components/PieChart.js
@@ -16,12 +16,40 @@ const PieChart = function ({
 }) {
   if (totalCount <= 0 || !data || data.length === 0) return null
   
-  const percent = data[0]
+  // const angle = data[0].count / totalCount * 2 * Math.PI
+  // <path d={`M 0 0 L 100 0 A ${R} ${R} 0 0 1 ${Math.cos(angle)*R} ${Math.sin(angle)*R} Z`} fill='#cc4444' />
+  
+  let totalAngle = 0
   
   return (
     <SVG viewBox={`${R*-1.2} ${R*-1.2} ${R*2.4} ${R*2.4}`}>
       <circle r={R} cx='0' cy='0' fill='#666666' />
-      <path d={`M 0 0 L 100 0 A 100 100 0 0 1 0 100 Z`} fill='#cc4444' />
+      <g>
+        {data.map((dataItem, index) => {
+          
+          const angle = dataItem.count / totalCount * 2 * Math.PI
+          const startAngle = totalAngle
+          const endAngle = startAngle + angle
+          const largeArcFlag = (angle > Math.PI) ? 1 : 0
+          const sweepFlag = 1  // Clockwise sweep!
+          
+          console.log('+++ ANGLE: ', dataItem.count / totalCount * 360)
+          console.log('+++ START: ', startAngle / 2 / Math.PI * 360)
+          
+          totalAngle += angle
+
+          if (dataItem.count <= 0) return null
+          
+          return (
+            <path
+              key={`pie-slice-${index}`}
+              d={`M 0 0 L ${Math.cos(startAngle)*R} ${Math.sin(startAngle)*R} A ${R} ${R} 0 ${largeArcFlag} ${sweepFlag} ${Math.cos(endAngle)*R} ${Math.sin(endAngle)*R} Z`}
+              fill='rgba(255, 0, 0, 0.2)'
+              stroke='#ffffff'
+            />
+          )
+        })}
+      </g>
     </SVG>
   )
 }

--- a/src/components/AggregationsViewer/components/PieChart.js
+++ b/src/components/AggregationsViewer/components/PieChart.js
@@ -11,19 +11,17 @@ const SVG = styled.svg`
 const R = 100
 
 const PieChart = function ({
+  colours,
   data,
   totalCount,
 }) {
   if (totalCount <= 0 || !data || data.length === 0) return null
   
-  // const angle = data[0].count / totalCount * 2 * Math.PI
-  // <path d={`M 0 0 L 100 0 A ${R} ${R} 0 0 1 ${Math.cos(angle)*R} ${Math.sin(angle)*R} Z`} fill='#cc4444' />
-  
   let totalAngle = 0
   
   return (
     <SVG viewBox={`${R*-1.2} ${R*-1.2} ${R*2.4} ${R*2.4}`}>
-      <circle r={R} cx='0' cy='0' fill='#666666' />
+      <circle r={R} cx='0' cy='0' fill='#fff' stroke='#eee' strokeWidth='4' />
       <g>
         {data.map((dataItem, index) => {
           
@@ -33,9 +31,6 @@ const PieChart = function ({
           const largeArcFlag = (angle > Math.PI) ? 1 : 0
           const sweepFlag = 1  // Clockwise sweep!
           
-          console.log('+++ ANGLE: ', dataItem.count / totalCount * 360)
-          console.log('+++ START: ', startAngle / 2 / Math.PI * 360)
-          
           totalAngle += angle
 
           if (dataItem.count <= 0) return null
@@ -44,7 +39,7 @@ const PieChart = function ({
             <path
               key={`pie-slice-${index}`}
               d={`M 0 0 L ${Math.cos(startAngle)*R} ${Math.sin(startAngle)*R} A ${R} ${R} 0 ${largeArcFlag} ${sweepFlag} ${Math.cos(endAngle)*R} ${Math.sin(endAngle)*R} Z`}
-              fill='rgba(255, 0, 0, 0.2)'
+              fill={(colours && colours[index]) || '#666666'}
               stroke='#ffffff'
             />
           )
@@ -55,6 +50,7 @@ const PieChart = function ({
 }
 
 PieChart.propTypes = {
+  colours: PropTypes.arrayOf(PropTypes.string),
   data: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
     count: PropTypes.number,
@@ -63,6 +59,7 @@ PieChart.propTypes = {
 }
 
 PieChart.defaultProps = {
+  colours: [],
   data: [],
   totalCount: 0,
 }

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -83,32 +83,6 @@ const SingleTask = function ({
       {summary}
       <FixedHeightBox background='#ffffff' expand={expand} pad='xsmall'>
         <Tabs>
-          <Tab title='Chart'>
-            <PieChart
-              colours={colours}
-              data={summarisedData}
-              totalCount={numClassifications}
-            />
-            {expand && (
-              <Box>
-                {summarisedData.map(({ label, count }, index) => (
-                  <Box key={`pie-key-${index}`} direction='row' align='center' gap='xsmall'>
-                    <TinyBox
-                      align='center'
-                      background={colours[index]}
-                      color='#fff'
-                      direction='column'
-                      size='xsmall'
-                      pad='xsmall'
-                    >
-                      <Text size='xsmall' color='#ffffff'>{'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[index]}</Text>
-                    </TinyBox>
-                    <Text size='xsmall'>{label}</Text>
-                  </Box>
-                ))}
-              </Box>
-            )}
-          </Tab>
           <Tab title='Q&amp;A'>
             <Paragraph flex={false}>{question}</Paragraph>
             {summarisedData.map(({ label, count }, index) => (
@@ -135,6 +109,32 @@ const SingleTask = function ({
                 </Box>
               </Box>
             ))}
+          </Tab>
+          <Tab title='Chart'>
+            <PieChart
+              colours={colours}
+              data={summarisedData}
+              totalCount={numClassifications}
+            />
+            {expand && (
+              <Box>
+                {summarisedData.map(({ label, count }, index) => (
+                  <Box key={`pie-key-${index}`} direction='row' align='center' gap='xsmall'>
+                    <TinyBox
+                      align='center'
+                      background={colours[index]}
+                      color='#fff'
+                      direction='column'
+                      size='xsmall'
+                      pad='xsmall'
+                    >
+                      <Text size='xsmall' color='#ffffff'>{'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[index]}</Text>
+                    </TinyBox>
+                    <Text size='xsmall'>{label}</Text>
+                  </Box>
+                ))}
+              </Box>
+            )}
           </Tab>
         </Tabs>
       </FixedHeightBox>

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -62,8 +62,8 @@ const SingleTask = function ({
   })
   
   const summary = <Paragraph>This image has been classified by <b>{numClassifications}</b> people.</Paragraph>
-  const footnote = (sanityCheck !== numClassifications)
-    ? <Text size='xsmall'>The number of classifications do not match the number of answers. There are many reasons for this - for example, a user might have submitted a classification with no answer.</Text>
+  const footnote = (sanityCheck !== numClassifications && expand)
+    ? <Text size='xsmall' margin='xsmall'>The number of classifications do not match the number of answers. There are many reasons for this - for example, a user might have submitted a classification with no answer.</Text>
     : null
   
   return (

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -50,14 +50,21 @@ const SingleTask = function ({
   }
   
   const maxCount = Object.values(reductionsData).reduce((max, cur) => Math.max(max, cur))
-  const summary = <Paragraph>This image has been classified by <b>{numClassifications}</b> people.</Paragraph>
-        
+  
+  let sanityCheck = 0
   const summarisedData = answers.map((ans, index) => {
+    const count = reductionsData[index] || 0
+    sanityCheck += count
     return {
       label: simplifyText(ans.label),
-      count: reductionsData[index] || 0,
+      count: count,
     }
   })
+  
+  const summary = <Paragraph>This image has been classified by <b>{numClassifications}</b> people.</Paragraph>
+  const footnote = (sanityCheck !== numClassifications)
+    ? <Text size='xsmall'>The number of classifications do not match the number of answers. There are many reasons for this - for example, a user might have submitted a classification with no answer.</Text>
+    : null
   
   return (
     <Box>
@@ -66,8 +73,8 @@ const SingleTask = function ({
         <Tabs>
           <Tab title='Chart'>
             <PieChart
-              maxCount={numClassifications}
               data={summarisedData}
+              totalCount={numClassifications}
             />
           </Tab>
           <Tab title='Q&amp;A'>
@@ -90,8 +97,8 @@ const SingleTask = function ({
                     values={[{ value: count, color: 'accent-4' }]}
                   />
                   <FixedWidthTextS flex={false}>{count}</FixedWidthTextS>
-                  {(expand && maxCount > 0) && (
-                    <FixedWidthTextM flex={false}>{(count / maxCount * 100).toFixed(1)}%</FixedWidthTextM>
+                  {(expand && numClassifications > 0) && (
+                    <FixedWidthTextM flex={false}>{(count / numClassifications * 100).toFixed(1)}%</FixedWidthTextM>
                   )}
                 </Box>
               </Box>
@@ -99,6 +106,7 @@ const SingleTask = function ({
           </Tab>
         </Tabs>
       </FixedHeightBox>
+      {footnote}
     </Box>
   )
 }

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -10,8 +10,13 @@ function simplifyText (text) {
     .replace(/!\[[^\]]*\]\([^\)]*\)/g, '')  // Remove Markdown images
 }
 
-const FixedWidthText = styled(Text)`
-  width: 5em;
+const FixedWidthTextS = styled(Text)`
+  width: 2.5em;
+  overflow: auto;
+`
+
+const FixedWidthTextM = styled(Text)`
+  width: 4em;
   overflow: auto;
 `
 
@@ -84,7 +89,10 @@ const SingleTask = function ({
                     max={maxCount}
                     values={[{ value: count, color: 'accent-4' }]}
                   />
-                  <FixedWidthText flex={false}>{count}</FixedWidthText>
+                  <FixedWidthTextS flex={false}>{count}</FixedWidthTextS>
+                  {(expand && maxCount > 0) && (
+                    <FixedWidthTextM flex={false}>{(count / maxCount * 100).toFixed(1)}%</FixedWidthTextM>
+                  )}
                 </Box>
               </Box>
             ))}

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import { Box, Meter, Paragraph, Tab, Tabs, Text } from 'grommet'
 import styled, { css } from 'styled-components'
 
+import PieChart from './PieChart'
+
 function simplifyText (text) {
   return text
     .replace(/!\[[^\]]*\]\([^\)]*\)/g, '')  // Remove Markdown images
@@ -58,10 +60,10 @@ const SingleTask = function ({
       <FixedHeightBox background='#ffffff' expand={expand} pad='xsmall'>
         <Tabs>
           <Tab title='Chart'>
-            <svg viewBox='-120 -120 240 240'>
-              <circle r='100' cx='0' cy='0' fill='#666666' />
-              <path d={`M 0 0 L 100 0 A 100 100 0 0 1 0 100 Z`} fill='#cc4444' />
-            </svg>
+            <PieChart
+              maxCount={numClassifications}
+              data={summarisedData}
+            />
           </Tab>
           <Tab title='Q&amp;A'>
             <Paragraph flex={false}>{question}</Paragraph>

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Meter, Paragraph, Tab, Tabs, Text } from 'grommet'
-import { StopFill as RectIcon } from 'grommet-icons'
 import styled from 'styled-components'
 
 import PieChart from './PieChart'
@@ -26,6 +25,13 @@ const FixedHeightBox = styled(Box)`
     ? ''
     : 'overflow: auto; max-height: 50vh;'
   }
+`
+
+const TinyBox = styled(Box)`
+  flex: 0 0 auto;
+  height: 2em;
+  width: 2em;
+  overflow: hidden;
 `
 
 const SingleTask = function ({
@@ -83,14 +89,25 @@ const SingleTask = function ({
               data={summarisedData}
               totalCount={numClassifications}
             />
-            <Box>
-              {summarisedData.map(({ label, count }, index) => (
-                <Box key={`pie-key-${index}`} direction='row' align='center'>
-                  <RectIcon color={colours[index]} />
-                  <Text size='xsmall' wordBreak='keep-all'>{label}</Text>
-                </Box>
-              ))}
-            </Box>
+            {expand && (
+              <Box>
+                {summarisedData.map(({ label, count }, index) => (
+                  <Box key={`pie-key-${index}`} direction='row' align='center' gap='xsmall'>
+                    <TinyBox
+                      align='center'
+                      background={colours[index]}
+                      color='#fff'
+                      direction='column'
+                      size='xsmall'
+                      pad='xsmall'
+                    >
+                      <Text size='xsmall' color='#ffffff'>{'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[index]}</Text>
+                    </TinyBox>
+                    <Text size='xsmall'>{label}</Text>
+                  </Box>
+                ))}
+              </Box>
+            )}
           </Tab>
           <Tab title='Q&amp;A'>
             <Paragraph flex={false}>{question}</Paragraph>

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Meter, Paragraph, Tab, Tabs, Text } from 'grommet'
+import { StopFill as RectIcon } from 'grommet-icons'
 import styled from 'styled-components'
 
 import PieChart from './PieChart'
@@ -66,6 +67,11 @@ const SingleTask = function ({
     ? <Text size='xsmall' margin='xsmall'>The number of classifications do not match the number of answers. There are many reasons for this - for example, a user might have submitted a classification with no answer.</Text>
     : null
   
+  const colours = summarisedData.map((dataItem, index) => {
+    const hue = index / summarisedData.length * 360
+    return `hsl(${hue}, 60%, 50%)`  // hsv(hue, 100%, 31%) matches Zooniverse's #00979d brand colour, but hsv(hue, 60%, 50%) is much better when differentiating between 6+ colours.
+  })
+  
   return (
     <Box>
       {summary}
@@ -73,9 +79,18 @@ const SingleTask = function ({
         <Tabs>
           <Tab title='Chart'>
             <PieChart
+              colours={colours}
               data={summarisedData}
               totalCount={numClassifications}
             />
+            <Box>
+              {summarisedData.map(({ label, count }, index) => (
+                <Box key={`pie-key-${index}`} direction='row' align='center'>
+                  <RectIcon color={colours[index]} />
+                  <Text size='xsmall' wordBreak='keep-all'>{label}</Text>
+                </Box>
+              ))}
+            </Box>
           </Tab>
           <Tab title='Q&amp;A'>
             <Paragraph flex={false}>{question}</Paragraph>

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Box, Meter, Paragraph, Text } from 'grommet'
+import { Box, Meter, Paragraph, Tab, Tabs, Text } from 'grommet'
 import styled, { css } from 'styled-components'
 
 function simplifyText (text) {
@@ -44,38 +44,50 @@ const SingleTask = function ({
   
   const maxCount = Object.values(reductionsData).reduce((max, cur) => Math.max(max, cur))
   const summary = <Paragraph>This image has been classified by <b>{numClassifications}</b> people.</Paragraph>
-
+        
+  const summarisedData = answers.map((ans, index) => {
+    return {
+      label: simplifyText(ans.label),
+      count: reductionsData[index] || 0,
+    }
+  })
+  
   return (
     <Box>
       {summary}
       <FixedHeightBox background='#ffffff' expand={expand} pad='xsmall'>
-        <Paragraph flex={false}>{question}</Paragraph>
-        {answers.map((ans, index) => {
-          const label = simplifyText(ans.label)
-          const count = reductionsData[index] || 0
-  
-          return (
-            <Box
-              flex={false}
-              key={`answer-${index}`}
-              margin='xsmall'
-            >
-              <Text size='xsmall'>{label}</Text>
+        <Tabs>
+          <Tab title='Chart'>
+            <svg viewBox='-120 -120 240 240'>
+              <circle r='100' cx='0' cy='0' fill='#666666' />
+              <path d={`M 0 0 L 100 0 A 100 100 0 0 1 0 100 Z`} fill='#cc4444' />
+            </svg>
+          </Tab>
+          <Tab title='Q&amp;A'>
+            <Paragraph flex={false}>{question}</Paragraph>
+            {summarisedData.map(({ label, count }, index) => (
               <Box
-                align='center'
-                direction='row'
-                gap='small'
+                flex={false}
+                key={`answer-${index}`}
+                margin='xsmall'
               >
-                <Meter
-                  flex='grow'
-                  max={maxCount}
-                  values={[{ value: count, color: 'accent-4' }]}
-                />
-                <FixedWidthText flex={false}>{count}</FixedWidthText>
+                <Text size='xsmall'>{label}</Text>
+                <Box
+                  align='center'
+                  direction='row'
+                  gap='small'
+                >
+                  <Meter
+                    flex='grow'
+                    max={maxCount}
+                    values={[{ value: count, color: 'accent-4' }]}
+                  />
+                  <FixedWidthText flex={false}>{count}</FixedWidthText>
+                </Box>
               </Box>
-            </Box>
-          )
-        })}
+            ))}
+          </Tab>
+        </Tabs>
       </FixedHeightBox>
     </Box>
   )

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Meter, Paragraph, Tab, Tabs, Text } from 'grommet'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import PieChart from './PieChart'
 
@@ -78,7 +78,7 @@ const SingleTask = function ({
                 key={`answer-${index}`}
                 margin='xsmall'
               >
-                <Text size='xsmall'>{label}</Text>
+                <Text size={(expand) ? 'small' : 'xsmall'}>{label}</Text>
                 <Box
                   align='center'
                   direction='row'

--- a/src/components/SubjectViewer/components/WorkflowControls.js
+++ b/src/components/SubjectViewer/components/WorkflowControls.js
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types'
 import { Box, Select, Text } from 'grommet'
 import styled from 'styled-components'
 
+function simplifyText (text) {
+  return text
+    .replace(/!\[[^\]]*\]\([^\)]*\)/g, '')  // Remove Markdown images
+}
+
 const WorkflowControls = function ({
   setTaskId,
   taskId,
@@ -17,7 +22,7 @@ const WorkflowControls = function ({
     const label = task.instruction || task.question
     
     return {
-      label: (label) ? `Task ${key}: ${label}` : `Task ${key}`,
+      label: (label) ? `Task ${key}: ${simplifyText(label)}` : `Task ${key}`,
       value: key,
     }
   })


### PR DESCRIPTION
## PR Overview

This PR adds a pie chart to the SingleTask (Single Answer Question Task) subcomponent of the Aggregations Viewer.

<img width="1240" alt="Screen Shot 2020-10-13 at 20 24 44" src="https://user-images.githubusercontent.com/13952701/95906652-4e997c00-0d92-11eb-8750-093b45f58324.png">

- The 'Chart' tab has been added to the SingleTask subcomponent.
- The text in the 'Q&A' tab is larger when expanded.
- The SingleTask component now shows percentages where possible.
