### PR TITLE
Add Cache-Control headers to uploads

### DIFF
--- a/bin/upload.js
+++ b/bin/upload.js
@@ -1,0 +1,29 @@
+/*
+  An S3 uploader with some useful default settings for Zooniverse static files.
+  Accepts a local path and an S3 path, relative to zooniverse-static, as its arguments.
+  Usage example: node upload.js ./build zoo-notes.zooniverse.org
+*/
+const Uploader = require('s3-batch-upload').default;
+
+const args = process.argv.slice(2);
+const [ localPath, remotePath ] = args;
+
+async function uploadBuild() {
+  const uploader = new Uploader({
+    bucket: 'zooniverse-static',
+    localPath,
+    remotePath,
+    concurrency: '200',
+    cacheControl: {
+      '**/index.html': 'max-age=60, s-maxage=60',
+      '**/*.*': 'public, max-age=604800, immutable'
+    },
+    accessControlLevel: 'public-read'
+  });
+
+  const files = await uploader.upload();
+  console.log('Uploaded to S3');
+  console.log(files.join('\n'));
+}
+
+uploadBuild();

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "export REACT_APP_HEAD_COMMIT=${HEAD_COMMIT:-$(git rev-parse --short HEAD)}; react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "_publish": "s3-batch-upload -b zooniverse-static -p ./build -C 200 -acl 'public-read' -r $PATH_ROOT",
+    "_publish": "node ./bin/upload.js ./build $PATH_ROOT",
     "deploy": "export PATH_ROOT=zoo-notes.zooniverse.org; yarn build && yarn _publish"
   },
   "eslintConfig": {


### PR DESCRIPTION
Move the S3 upload config into its own script. Add Cache-Control headers to give us 60s caching of index.html and 604800s (7 days) for all other static assets.