### PR TITLE
Turn off the linter failures so build works

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "start": "export REACT_APP_HEAD_COMMIT=${HEAD_COMMIT:-$(git rev-parse --short HEAD)}; react-scripts start",
-    "build": "export REACT_APP_HEAD_COMMIT=${HEAD_COMMIT:-$(git rev-parse --short HEAD)}; react-scripts build",
+    "build": "export REACT_APP_HEAD_COMMIT=${HEAD_COMMIT:-$(git rev-parse --short HEAD)} CI=false; react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "_publish": "node ./bin/upload.js ./build $PATH_ROOT",


### PR DESCRIPTION
Setting `CI=false` for the build so that the GA production deploy works and doesn't fail on linter warnings.