### PR TITLE
SLOAN Grant Experiment - ClusterViewer v1 and Subject Inspector

### DIFF
--- a/src/experimental-sloan/components/ClusterViewer1.jsx
+++ b/src/experimental-sloan/components/ClusterViewer1.jsx
@@ -176,6 +176,15 @@ function SubjectInspector ({
     )
   }
 
+  const metadata = (!subject.metadata)
+    ? []
+    : Object.keys(subject.metadata).map(key => {
+      return {
+        key,
+        value: subject.metadata[key]
+      }
+    })
+
   return (
     <Box border={true} pad='small' margin={{ vertical: 'xsmall', horizontal: 'none' }}>
       <Box direction='row'>
@@ -189,11 +198,16 @@ function SubjectInspector ({
           plain={true}
         />
       </Box>
-      <NameValueList>
-        <NameValuePair name='subject_id'>
-          <Text></Text>
-        </NameValuePair>
-      </NameValueList>
+      {metadata.length === 0 && <Text>This Subject has no metadata</Text>}
+      {metadata.length > 0 && (
+        <NameValueList>
+          {metadata.map(m => (
+            <NameValuePair key={m.key} name={m.key}>
+              <Text>{m.value}</Text>
+            </NameValuePair>
+          ))}
+        </NameValueList>
+      )}
     </Box>
   )
 

--- a/src/experimental-sloan/components/ClusterViewer1.jsx
+++ b/src/experimental-sloan/components/ClusterViewer1.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { Box, NameValueList, NameValuePair, Text } from 'grommet'
+import { Box, Button, NameValueList, NameValuePair, Text } from 'grommet'
+import { FormClose } from 'grommet-icons'
 import styled from 'styled-components'
 import stopEvent from '../helpers/stopEvent'
 
@@ -38,13 +39,17 @@ function ClusterViewer1 ({
   width = DEFAULT_SIZE,
   height = DEFAULT_SIZE,
 }) {
-  const [selectedSubjectId, setSelectedSubjectId] = useState(undefined)
+  const [selectedSubject, setSelectedSubject] = useState(undefined)
 
   const subjectsInCluster = Object.values(subjects).filter(sbj => cluster.subject_ids.includes(parseInt(sbj.id)))
+
   const selectSubject = (subjectId) => {
-    console.log('x', subjectId)
-    setSelectedSubjectId(subjectId)
+    const selectedSubject = Object.values(subjects).find(sbj => sbj.id === subjectId)
+    console.log('selectSubject: ', subjectId, selectedSubject)
+    setSelectedSubject(selectedSubject)
   }
+
+  const closeSubjectInspector = () => { selectSubject(undefined) }
 
   return (
     <Container
@@ -81,6 +86,7 @@ function ClusterViewer1 ({
               key={subject.id}
               subject={subject}
               cx={cx} cy={cy} size={CELL_SIZE}
+              isSelected={subject.id === selectedSubject}
               onSelect={selectSubject}
             />
           )
@@ -90,10 +96,16 @@ function ClusterViewer1 ({
           <Cell  /* Main cell is in the centre */
             subject={subjects[mainSubjectId]}
             cx={0} cy={0} size={CELL_SIZE}
+            isSelected={mainSubjectId === selectedSubject}
+            onSelect={selectSubject}
             type='main'
           />
         )}
       </SVG>
+      <SubjectInspector
+        subject={selectedSubject}
+        onClose={closeSubjectInspector}
+      />
       <Text size='small'>ClusterViewer v1</Text>
     </Container>
   )
@@ -149,8 +161,42 @@ function Cell ({
         y={-size/2}
       />
     </g>
-
   )
+}
+
+function SubjectInspector ({
+  subject,
+  onClose,
+}) {
+  if (!subject) {
+    return (
+      <Box>
+        <Text>Click on a Subject to inspect it.</Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Box border={true} pad='small' margin={{ vertical: 'xsmall', horizontal: 'none' }}>
+      <Box direction='row'>
+        <Box flex={true}>
+          <Text weight='bold'>Subject {subject.id}</Text>
+        </Box>
+        <Button
+          a11yTitle='Close Subject Inspector'
+          icon={<FormClose />}
+          onClick={onClose}
+          plain={true}
+        />
+      </Box>
+      <NameValueList>
+        <NameValuePair name='subject_id'>
+          <Text></Text>
+        </NameValuePair>
+      </NameValueList>
+    </Box>
+  )
+
 }
 
 export { ClusterViewer1 }

--- a/src/experimental-sloan/components/ClusterViewer1.jsx
+++ b/src/experimental-sloan/components/ClusterViewer1.jsx
@@ -14,11 +14,20 @@ const Container = styled(Box)`
 const SVG = styled('svg')`
   border: 1px solid rgba(128, 128, 128, 0.5);
   max-width: ${DEFAULT_SIZE}px;
+  background: #222222;
+`
+
+const SelectableCircle = styled('circle')`
+  cursor: pointer;
+`
+
+const SelectableImage = styled('image')`
+  cursor: pointer;
 `
 
 const STYLES = {
   AXIS: {
-    STROKE: 'rgba(128, 128, 128, 0.5)'
+    STROKE: 'rgba(255, 255, 255, 0.5)'
   },
   CELL: {
     FILL: '#cccccc',
@@ -27,10 +36,15 @@ const STYLES = {
   },
   MAIN_CELL: {
     STROKE: '#44cccc',
-  }
+  },
+  SELECTED_CELL: {
+    STROKE: '#00ffff',
+    STROKE_WIDTH: 10,
+  },
 }
 
 const CELL_SIZE = 100
+const DISTANCE_BETWEEN_CELLS = 110
 
 function ClusterViewer1 ({
   mainSubjectId = '',
@@ -45,7 +59,6 @@ function ClusterViewer1 ({
 
   const selectSubject = (subjectId) => {
     const selectedSubject = Object.values(subjects).find(sbj => sbj.id === subjectId)
-    console.log('selectSubject: ', subjectId, selectedSubject)
     setSelectedSubject(selectedSubject)
   }
 
@@ -77,7 +90,7 @@ function ClusterViewer1 ({
         </g>
 
         {subjectsInCluster.map((subject, index) => {  /* Place Subjects in the cluster around the main cell*/
-          const dist = CELL_SIZE
+          const dist = DISTANCE_BETWEEN_CELLS
           const angle = index / subjectsInCluster.length * 2 * Math.PI - 0.5 * Math.PI
           const cx = dist * Math.cos(angle)
           const cy = dist * Math.sin(angle)
@@ -86,7 +99,7 @@ function ClusterViewer1 ({
               key={subject.id}
               subject={subject}
               cx={cx} cy={cy} size={CELL_SIZE}
-              isSelected={subject.id === selectedSubject}
+              isSelected={subject.id === selectedSubject?.id}
               onSelect={selectSubject}
             />
           )
@@ -96,7 +109,7 @@ function ClusterViewer1 ({
           <Cell  /* Main cell is in the centre */
             subject={subjects[mainSubjectId]}
             cx={0} cy={0} size={CELL_SIZE}
-            isSelected={mainSubjectId === selectedSubject}
+            isSelected={mainSubjectId === selectedSubject?.id}
             onSelect={selectSubject}
             type='main'
           />
@@ -116,6 +129,7 @@ function Cell ({
   size = 100,
   cx = 0,
   cy = 0,
+  isSelected = false,
   onSelect = () => {},
   type = '',
 }) {
@@ -136,6 +150,14 @@ function Cell ({
     }
   }
 
+  let stroke = STYLES.CELL.STROKE
+  if (type === 'main') stroke = STYLES.MAIN_CELL.STROKE
+  if (isSelected) stroke = STYLES.SELECTED_CELL.STROKE
+
+  const strokeWidth = (isSelected)
+    ? STYLES.SELECTED_CELL.STROKE_WIDTH
+    : STYLES.CELL.STROKE_WIDTH
+
   return (
     <g
       transform={`translate(${cx} ${cy})`}
@@ -144,15 +166,19 @@ function Cell ({
       onKeyPress={onKeyPress}
     >
       <mask id={`cell-subject-id-${subjectId}`}>
-        <circle cx={0} cy={0} r={size/2} fill='#fff'/>
+        <circle
+          cx={0} cy={0} r={size/2}
+          fill='#fff'
+          strokeWidth={strokeWidth}
+        />
       </mask>
-      <circle
+      <SelectableCircle
         cx={0} cy={0} r={size/2}
         fill={STYLES.CELL.FILL}
-        stroke={(type === 'main') ? STYLES.MAIN_CELL.STROKE : STYLES.CELL.STROKE}
-        strokeWidth={STYLES.CELL.STROKE_WIDTH}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
       />
-      <image
+      <SelectableImage
         xlinkHref={imageUrl}
         mask={`url(#cell-subject-id-${subjectId})`}
         width={size}

--- a/src/experimental-sloan/components/ClusterViewer1.jsx
+++ b/src/experimental-sloan/components/ClusterViewer1.jsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import { Box, NameValueList, NameValuePair, Text } from 'grommet'
 import styled from 'styled-components'
+import stopEvent from '../helpers/stopEvent'
 
 const DEFAULT_SIZE = 500
 
@@ -36,7 +38,13 @@ function ClusterViewer1 ({
   width = DEFAULT_SIZE,
   height = DEFAULT_SIZE,
 }) {
+  const [selectedSubjectId, setSelectedSubjectId] = useState(undefined)
+
   const subjectsInCluster = Object.values(subjects).filter(sbj => cluster.subject_ids.includes(parseInt(sbj.id)))
+  const selectSubject = (subjectId) => {
+    console.log('x', subjectId)
+    setSelectedSubjectId(subjectId)
+  }
 
   return (
     <Container
@@ -70,8 +78,10 @@ function ClusterViewer1 ({
           const cy = dist * Math.sin(angle)
           return (
             <Cell
+              key={subject.id}
               subject={subject}
               cx={cx} cy={cy} size={CELL_SIZE}
+              onSelect={selectSubject}
             />
           )
         })}
@@ -94,6 +104,7 @@ function Cell ({
   size = 100,
   cx = 0,
   cy = 0,
+  onSelect = () => {},
   type = '',
 }) {
   const subjectId = subject.id
@@ -101,8 +112,25 @@ function Cell ({
 
   // TODO: determine Subject Image Size
 
+  const onClick = (e) => {
+    onSelect(subjectId)
+    stopEvent(e)
+  }
+
+  const onKeyPress = (e) => {
+    if (e?.key === 'Enter') {
+      onSelect(subjectId)
+      stopEvent(e)
+    }
+  }
+
   return (
-    <g transform={`translate(${cx} ${cy})`}>
+    <g
+      transform={`translate(${cx} ${cy})`}
+      tabIndex='0'
+      onClick={onClick}
+      onKeyPress={onKeyPress}
+    >
       <mask id={`cell-subject-id-${subjectId}`}>
         <circle cx={0} cy={0} r={size/2} fill='#fff'/>
       </mask>

--- a/src/experimental-sloan/data/subjects.json
+++ b/src/experimental-sloan/data/subjects.json
@@ -1,7 +1,12 @@
 {
   "61582335": {
     "id": "61582335",
-    "metadata": {},
+    "metadata": {
+      "shape": "smooth",
+      "rounded": "inbetween",
+      "merging": "none",
+      "rare_features": "nothing_unusual"
+    },
     "locations": [
       {
         "image/jpeg": "https://panoptes-uploads.zooniverse.org/subject_location/88fecad7-14e1-4932-a6d0-ecf5b58f1938.jpeg"
@@ -27,7 +32,9 @@
 
   "61582385": {
     "id": "61582385",
-    "metadata": {},
+    "metadata": {
+      "shape": "artifact"
+    },
     "locations": [
       {
         "image/jpeg": "https://panoptes-uploads.zooniverse.org/subject_location/9b9c170c-75c7-4ce1-87f2-f164dae3edcf.jpeg"
@@ -40,7 +47,13 @@
 
   "61511516": {
     "id": "61511516",
-    "metadata": {},
+    "metadata": {
+      "shape": "features or disk",
+      "disk": "no",
+      "bar": "no",
+      "spiral_arm": "no",
+      "bulge": "no bulge"
+    },
     "locations": [
       {
         "image/jpeg": "https://panoptes-uploads.zooniverse.org/subject_location/51be0d53-293a-452d-b7f7-d6cc23ac691d.jpeg"
@@ -53,7 +66,12 @@
 
   "61582328": {
     "id": "61582328",
-    "metadata": {},
+    "metadata": {
+      "shape": "smooth",
+      "rounded": "cigar",
+      "merging": "none",
+      "rare_features": "nothing_unusual"
+    },
     "locations": [
       {
         "image/jpeg": "https://panoptes-uploads.zooniverse.org/subject_location/21e14d5e-02b8-4d49-b2bf-a9f023db77bc.jpeg"
@@ -66,7 +84,13 @@
 
   "61511551": {
     "id": "61511551",
-    "metadata": {},
+    "metadata": {
+      "shape": "features or disk",
+      "disk": "no",
+      "bar": "no",
+      "spiral_arm": "no",
+      "bulge": "no bulge"
+    },
     "locations": [
       {
         "image/jpeg": "https://panoptes-uploads.zooniverse.org/subject_location/623d197b-f14a-405c-a938-09d83bc34765.jpeg"

--- a/src/experimental-sloan/helpers/stopEvent.js
+++ b/src/experimental-sloan/helpers/stopEvent.js
@@ -1,0 +1,8 @@
+export default function stopEvent (e) {
+  if (!e) return false
+  e.preventDefault && e.preventDefault()
+  e.stopPropagation && e.stopPropagation()
+  e.returnValue = false
+  e.cancelBubble = true
+  return false
+}

--- a/src/experimental-sloan/pages/ExperimentsPage.js
+++ b/src/experimental-sloan/pages/ExperimentsPage.js
@@ -46,7 +46,7 @@ function ExperimentsPage () {
           other galaxies in the cluster are being compared to.
         </ConstrainedParagraph>
         <ClusterViewer1
-          mainSubjectId={ex1_showMain ? 61582335 : undefined}
+          mainSubjectId={ex1_showMain ? '61582335' : undefined}
           subjects={subjects}
           cluster={clusters['subject_id=61582335']}
         />
@@ -72,7 +72,7 @@ function ExperimentsPage () {
           Hex clustering?
         </ConstrainedParagraph>
         <ClusterViewer1
-          mainSubjectId={ex2_showMain ? 61511507 : undefined}
+          mainSubjectId={ex2_showMain ? '61511507' : undefined}
           subjects={subjects}
           cluster={clusters['subject_id=61511507']}
         />


### PR DESCRIPTION
## PR Overview

Part of the SLOAN Grant Experiment. See #58 for context

This PR improves the ClusterViewer v1 with a Subject Inspector, and improves styles.

- A ClusterViewer should be navigable with either keyboard or mouse.
- Clicking on a Subject (a galaxy) should bring up some (currently fake) details about said galaxy, mined from the metadata. (Presumably in the future, we'd find more interesting info on individual galaxies from the planned cluster API.)

### Status

Merging as an experimental build.

The experiment will be viewable at https://zoo-notes.zooniverse.org/experimental