### PR TITLE
APPEASE THE LINTER!

### DIFF
--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -7,7 +7,7 @@ import PieChart from './PieChart'
 
 function simplifyText (text) {
   return text
-    .replace(/!\[[^\]]*\]\([^\)]*\)/g, '')  // Remove Markdown images
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')  // Remove Markdown images
 }
 
 const FixedWidthTextS = styled(Text)`

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -28,12 +28,24 @@ const SubjectViewer = React.forwardRef(function ({
   const [isMoving, setIsMoving] = useState(false)
   
   useEffect(() => {
-    interactionRef.current && interactionRef.current.addEventListener('wheel', onWheel, { passive: false })
+    const svg = interactionRef.current
+    const onWheel = (e) => {
+      e.preventDefault()
+      const WHEEL_STEP = 0.1
+    
+      if (e.deltaY < 0) {
+        setZoom(WHEEL_STEP, true)
+      } else if (e.deltaY > 0) {
+        setZoom(-WHEEL_STEP, true)
+      }
+    }
+
+    svg?.addEventListener('wheel', onWheel, { passive: false })
     
     return () => {
-      interactionRef.current && interactionRef.current.removeEventListener('wheel', onWheel)
+      svg?.removeEventListener('wheel', onWheel)
     }
-  }, [interactionRef.current])
+  }, [setZoom])
 
   if (!imageUrl || imageUrl.length === 0 || !containerRef) return null
 
@@ -66,17 +78,6 @@ const SubjectViewer = React.forwardRef(function ({
   const onMouseUpOrLeave = (e) => {
     e.preventDefault()
     setIsMoving(false)
-  }
-  
-  const onWheel = (e) => {
-    e.preventDefault()
-    const WHEEL_STEP = 0.1
-    
-    if (e.deltaY < 0) {
-      setZoom(WHEEL_STEP, true)
-    } else if (e.deltaY > 0) {
-      setZoom(-WHEEL_STEP, true)
-    }
   }
 
   return (

--- a/src/components/SubjectViewer/components/WorkflowControls.js
+++ b/src/components/SubjectViewer/components/WorkflowControls.js
@@ -4,7 +4,7 @@ import { Box, Select, Text } from 'grommet'
 
 function simplifyText (text) {
   return text
-    .replace(/!\[[^\]]*\]\([^\)]*\)/g, '')  // Remove Markdown images
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')  // Remove Markdown images
 }
 
 const WorkflowControls = function ({

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -34,7 +34,7 @@ const WorkflowObserver = function ({
   function handleClassification (data) {
     if (!data) return
     
-    if (workflowId && data.workflow_id != workflowId) return  // Use loose comparison since we might be dealing with strings or numbers
+    if (workflowId && parseInt(data.workflow_id) !== parseInt(workflowId)) return
     
     const subjectId = data.subject_ids && data.subject_ids[0]
     if (!subjectId) return


### PR DESCRIPTION
This fixes a few linter warnings during the build.
- Remove redundant escape characters from regular expressions.
- Force workflow IDs to ints before comparing them.
- Move external dependencies inside the effect for the `onWheel` handler in the subject viewer.