### PR TITLE
Remove the React global

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import './App.css';
 
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
@@ -27,7 +27,7 @@ function checkToken(store) {
 function App() {
   const store = useContext(AppContext)
 
-  React.useEffect(() => {
+  useEffect(() => {
     store.initialise()
     // apiClient.beforeEveryRequest = () => checkToken(store)
   }, [store])

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 

--- a/src/components/AggregationsViewer/AggregationsViewer.js
+++ b/src/components/AggregationsViewer/AggregationsViewer.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { Box, Button, Text } from 'grommet'
 import AppContext from 'stores'
 import { observer } from 'mobx-react'
@@ -25,9 +25,9 @@ const CompactButton = styled(Button)`
 `
 
 function AggregationsViewer () {
-  const store = React.useContext(AppContext)
+  const store = useContext(AppContext)
   const colors = mergedTheme.global.colors
-  const [expand, setExpand] = React.useState(false)
+  const [expand, setExpand] = useState(false)
   
   const selectedTask = store.workflow.selectedTask
   const selectedTaskType = store.workflow.selectedTaskType
@@ -36,7 +36,7 @@ function AggregationsViewer () {
   const aggregationData = store.aggregations.current && store.aggregations.current.workflow
   
   // Is the selected task best seen in an expanded view?
-  React.useEffect(() => {
+  useEffect(() => {
     if (selectedTaskType === 'single') setExpand(true)
   }, [selectedTaskType])  // Only listen when selectedTaskType changes.
   

--- a/src/components/AggregationsViewer/components/DrawingTask.js
+++ b/src/components/AggregationsViewer/components/DrawingTask.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Paragraph } from 'grommet'
 

--- a/src/components/AggregationsViewer/components/PieChart.js
+++ b/src/components/AggregationsViewer/components/PieChart.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Meter, Paragraph, Tab, Tabs, Text } from 'grommet'
 import styled from 'styled-components'

--- a/src/components/LargeMessageBox/LargeMessageBox.js
+++ b/src/components/LargeMessageBox/LargeMessageBox.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Box } from 'grommet'

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { forwardRef, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
@@ -13,7 +13,7 @@ const SVG = styled.svg`
   }
 `
 
-const SubjectViewer = React.forwardRef(function ({
+const SubjectViewer = forwardRef(function ({
   imageUrl,
   imageWidth,
   imageHeight,

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import { Box, Text } from 'grommet'
 import AppContext from 'stores'
 import { observer } from 'mobx-react'
@@ -29,17 +29,17 @@ function findCurrentSrc (locations, index) {
 }
 
 function SubjectViewerContainer () {
-  const store = React.useContext(AppContext)
+  const store = useContext(AppContext)
   const colors = mergedTheme.global.colors
   const locations = store.subject.locations
   
   const src = findCurrentSrc(locations, store.subject.page)
-  const containerRef = React.useRef(null)
-  const [imageObject, setImageObject] = React.useState(new Image())
-  const [imageWidth, setImageWidth] = React.useState(0)
-  const [imageHeight, setImageHeight] = React.useState(0)
+  const containerRef = useRef(null)
+  const [imageObject, setImageObject] = useState(new Image())
+  const [imageWidth, setImageWidth] = useState(0)
+  const [imageHeight, setImageHeight] = useState(0)
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function fetchImage() {
       return new Promise((resolve, reject) => {
         imageObject.onload = () => resolve(imageObject)

--- a/src/components/SubjectViewer/components/AggregationsPane.js
+++ b/src/components/SubjectViewer/components/AggregationsPane.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 const STROKE_WIDTH_RATIO = 0.1

--- a/src/components/SubjectViewer/components/ViewerControls.js
+++ b/src/components/SubjectViewer/components/ViewerControls.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { Button, Box, Select, Text } from 'grommet'
 import {

--- a/src/components/SubjectViewer/components/WorkflowControls.js
+++ b/src/components/SubjectViewer/components/WorkflowControls.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Select, Text } from 'grommet'
 

--- a/src/components/WorkflowInputBox/WorkflowInputBox.js
+++ b/src/components/WorkflowInputBox/WorkflowInputBox.js
@@ -1,10 +1,10 @@
-import React from 'react'
+import { useRef } from 'react'
 import { Box, Button, TextInput } from 'grommet'
 import { FormNext as NextIcon } from 'grommet-icons'
 import { useHistory } from 'react-router-dom'
 
 const WorkflowInputBox = function () {
-  const workflowInput = React.useRef(null)
+  const workflowInput = useRef(null)
   const history = useHistory()
   
   function goToWorkflow () {

--- a/src/components/WorkflowObserver/WorkflowObserver.js
+++ b/src/components/WorkflowObserver/WorkflowObserver.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Anchor, Box, Button, Card, CardHeader, CardBody, Image, Text } from 'grommet'
 import { Clear as ClearIcon } from 'grommet-icons'
@@ -29,7 +29,7 @@ const WorkflowObserver = function ({
   workflowId
 }) {
   const initialSubjects = loadFromLocalStorage(getKey(workflowId)) || []
-  const [recentSubjects, setRecentSubjects] = React.useState(initialSubjects)
+  const [recentSubjects, setRecentSubjects] = useState(initialSubjects)
   
   function handleClassification (data) {
     if (!data) return
@@ -74,7 +74,7 @@ const WorkflowObserver = function ({
     setRecentSubjects([])
   }
   
-  React.useEffect(() => {
+  useEffect(() => {
     if (!pusher) {
       pusher = new Pusher(config.pusherAppKey)
     }

--- a/src/helpers/withThemeContext.js
+++ b/src/helpers/withThemeContext.js
@@ -1,5 +1,4 @@
 import { ThemeContext } from 'grommet'
-import React from 'react'
 
 function withThemeContext (WrappedComponent, theme) {
   return props => (

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
   document.getElementById('root')
 );
 

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useEffect } from 'react'
 import { Anchor, Box, Button, Heading, Paragraph } from 'grommet'
 import { FormNext as NextIcon } from 'grommet-icons'
 import { Link } from 'react-router-dom'
@@ -14,7 +14,7 @@ const ConstrainedBox = styled(Box)`
 `
 
 function HomePage () {
-  React.useEffect(() => {
+  useEffect(() => {
     return () => {}
   })
   

--- a/src/pages/MainLayout.js
+++ b/src/pages/MainLayout.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Anchor, Box, Footer, Header, Heading, Image, Menu, Text } from 'grommet'
 import { Menu as MenuIcon } from 'grommet-icons'
 import { useHistory, withRouter, Link } from 'react-router-dom'

--- a/src/pages/SubjectPage.js
+++ b/src/pages/SubjectPage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useContext, useEffect } from 'react'
 import { Box, Heading, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import { withRouter } from 'react-router-dom'
@@ -13,11 +13,11 @@ const OverflowBox = styled(Box)`
 `
 
 function SubjectPage ({ match }) {
-  const store = React.useContext(AppContext)
+  const store = useContext(AppContext)
   const workflowId = match.params.workflowId
   const subjectId = match.params.subjectId
   
-  React.useEffect(() => {
+  useEffect(() => {
     // Fetch Subject!
     store.subject.fetchSubject(subjectId)
     

--- a/src/pages/WorkflowPage.js
+++ b/src/pages/WorkflowPage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useContext, useEffect } from 'react'
 import { Box, Heading, Paragraph, Text } from 'grommet'
 import styled from 'styled-components'
 import { observer } from 'mobx-react'
@@ -17,10 +17,10 @@ const ConstrainedBox = styled(Box)`
 `
 
 function WorkflowPage ({ match }) {
-  const store = React.useContext(AppContext)
+  const store = useContext(AppContext)
   const workflowId = match.params.workflowId
   
-  React.useEffect(() => {
+  useEffect(() => {
     store.workflow.fetchWorkflow(workflowId)
     
     return () => {}


### PR DESCRIPTION
`react-scripts` 4 supports the new JSX transform, so we can remove the `React` global from our JSX files.