### PR TITLE
Upgrade to `react-router` v6

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import { useContext, useEffect } from 'react';
 import './App.css';
 
-import { BrowserRouter, Route, Switch } from 'react-router-dom'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { Grommet } from 'grommet'
 import { observer } from 'mobx-react'
 // import apiClient from 'panoptes-client/lib/api-client'
@@ -39,28 +39,28 @@ function App() {
       <main>
         <Grommet theme={mergedTheme}>
           <MainLayout>
-            <Switch>
+            <Routes>
               <Route
-                exact path='/'
-                component={HomePage}
+                path='/'
+                element={<HomePage />}
               />
               <Route
-                exact path='/view/workflow/:workflowId/subject/:subjectId'
-                component={SubjectPage}
+                path='/view/workflow/:workflowId/subject/:subjectId'
+                element={<SubjectPage />}
               />
               <Route
-                exact path='/view/workflow/:workflowId'
-                component={WorkflowPage}
+                path='/view/workflow/:workflowId'
+                element={<WorkflowPage />}
               />
               <Route
-                exact path='/view'
-                component={WorkflowPage}
+                path='/view'
+                element={<WorkflowPage />}
               />
               <Route
-                exact path='/experimental'
-                component={ExperimentsPage}
+                path='/experimental'
+                element={<ExperimentsPage />}
               />
-            </Switch>
+            </Routes>
           </MainLayout>
         </Grommet>
       </main>

--- a/src/components/WorkflowInputBox/WorkflowInputBox.js
+++ b/src/components/WorkflowInputBox/WorkflowInputBox.js
@@ -1,16 +1,16 @@
 import { useRef } from 'react'
 import { Box, Button, TextInput } from 'grommet'
 import { FormNext as NextIcon } from 'grommet-icons'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 
 const WorkflowInputBox = function () {
   const workflowInput = useRef(null)
-  const history = useHistory()
+  const navigate = useNavigate()
   
   function goToWorkflow () {
     let value = (workflowInput.current && workflowInput.current.value) || ''
     value = value.replace(/\D/g, '')
-    if (value.length > 0) history.push(`/view/workflow/${value}`)
+    if (value.length > 0) navigate(`/view/workflow/${value}`)
   }
   
   return (

--- a/src/pages/MainLayout.js
+++ b/src/pages/MainLayout.js
@@ -1,6 +1,6 @@
 import { Anchor, Box, Footer, Header, Heading, Image, Menu, Text } from 'grommet'
 import { Menu as MenuIcon } from 'grommet-icons'
-import { useHistory, withRouter, Link } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 import zooniverseLogo from 'images/zooniverse-logo-white-192.png'
@@ -17,7 +17,7 @@ const StyledHeading = styled(Heading)`
 `
 
 function MainLayout ({ children }) {
-  const history= useHistory()
+  const navigate = useNavigate()
 
   return (
     <>
@@ -37,11 +37,11 @@ function MainLayout ({ children }) {
           items={[
             {
               label: 'Home',
-              onClick: e => history.push('/'),
+              onClick: e => navigate('/'),
             },
             {
               label: 'Observe all Classifications',
-              onClick: e => history.push('/view'),
+              onClick: e => navigate('/view'),
             },
           ]}
         />
@@ -58,5 +58,4 @@ function MainLayout ({ children }) {
   )
 }
 
-export { MainLayout }
-export default withRouter(MainLayout)
+export default MainLayout

--- a/src/pages/SubjectPage.js
+++ b/src/pages/SubjectPage.js
@@ -1,7 +1,7 @@
 import { useContext, useEffect } from 'react'
 import { Box, Heading, Text } from 'grommet'
 import { observer } from 'mobx-react'
-import { withRouter } from 'react-router-dom'
+import { useParams } from 'react-router'
 import styled from 'styled-components'
 import AppContext from 'stores'
 
@@ -12,10 +12,9 @@ const OverflowBox = styled(Box)`
   overflow: auto;
 `
 
-function SubjectPage ({ match }) {
+function SubjectPage () {
   const store = useContext(AppContext)
-  const workflowId = match.params.workflowId
-  const subjectId = match.params.subjectId
+  const { subjectId, workflowId } = useParams()
   
   useEffect(() => {
     // Fetch Subject!
@@ -47,4 +46,4 @@ function SubjectPage ({ match }) {
 }
 
 export { SubjectPage }
-export default withRouter(observer(SubjectPage))
+export default observer(SubjectPage)

--- a/src/pages/WorkflowPage.js
+++ b/src/pages/WorkflowPage.js
@@ -1,8 +1,8 @@
 import { useContext, useEffect } from 'react'
 import { Box, Heading, Paragraph, Text } from 'grommet'
-import styled from 'styled-components'
 import { observer } from 'mobx-react'
-import { withRouter } from 'react-router-dom'
+import { useParams } from 'react-router'
+import styled from 'styled-components'
 import AppContext from 'stores'
 
 import WorkflowObserver from 'components/WorkflowObserver'
@@ -16,9 +16,9 @@ const ConstrainedBox = styled(Box)`
   max-width: 40rem;
 `
 
-function WorkflowPage ({ match }) {
+function WorkflowPage () {
   const store = useContext(AppContext)
-  const workflowId = match.params.workflowId
+  const { workflowId } = useParams()
   
   useEffect(() => {
     store.workflow.fetchWorkflow(workflowId)
@@ -60,4 +60,4 @@ function WorkflowPage ({ match }) {
 }
 
 export { WorkflowPage }
-export default withRouter(observer(WorkflowPage))
+export default observer(WorkflowPage)


### PR DESCRIPTION
Upgrade to the new hooks API in `react-router` 6, following [the migration guide for v5](https://reactrouterdotcom.fly.dev/docs/en/v6/upgrading/v5).
- replace `<Switch>` with `<Routes>`.
- replace `useHistory` with `useNavigate`.
- remove `withRouter`.
- remove `exact` from routes.
- replace `component` with `element` in routes.
- replace `match` with `useParams`.