### PR TITLE
Refactor data-fetching with hooks

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,2 @@
+export { default as useCaesar } from './useCaesar'
+export { default as usePanoptes } from './usePanoptes'

--- a/src/hooks/useCaesar.js
+++ b/src/hooks/useCaesar.js
@@ -1,0 +1,61 @@
+import { useContext, useEffect, useState } from 'react'
+import { request, gql } from 'graphql-request'
+import { applySnapshot } from 'mobx-state-tree'
+import ASYNC_STATES from 'helpers/asyncStates'
+import { config } from 'config'
+import AppContext from 'stores'
+
+async function fetchAggregations(subjectID, workflowID) {
+  if (!workflowID) throw Error('Can\'t fetch aggregations without a valid workflow')
+
+  const query = gql`{
+    workflow(id: ${workflowID}) {
+      reductions(subjectId: ${subjectID}) {
+        data
+      }
+      extracts(subjectId: ${subjectID}) {
+        data
+      }
+    }
+  }`
+
+  return await request(config.caesar, query)
+}
+
+export default function useCaesar(subjectID, workflowID) {
+  const store = useContext(AppContext)
+  const [data, setData] = useState(null)
+  const [error, setError] = useState()
+  const [loadingState, setLoadingState] = useState(ASYNC_STATES.IDLE)
+
+  useEffect(() => {
+    async function loadData() {
+      setLoadingState(ASYNC_STATES.LOADING)
+      try {
+        const newData = await fetchAggregations(subjectID, workflowID)
+        setData(newData)
+        setLoadingState(ASYNC_STATES.READY)
+      } catch (error) {
+        console.error(error)
+        setError(error.message)
+        setLoadingState(ASYNC_STATES.ERROR)
+      }
+    }
+
+    loadData(subjectID, workflowID)
+  }, [subjectID, workflowID])
+
+  if (loadingState === ASYNC_STATES.READY) {
+    applySnapshot(store.aggregations, {
+      current: data,
+      asyncState: loadingState
+    })
+    store.aggregations.extractData()
+  }
+  if (loadingState === ASYNC_STATES.ERROR) {
+    applySnapshot(store.aggregations, {
+      error,
+      asyncState: loadingState
+    })
+  }
+}

--- a/src/hooks/usePanoptes.js
+++ b/src/hooks/usePanoptes.js
@@ -1,0 +1,13 @@
+import { useContext, useEffect } from 'react'
+import AppContext from 'stores'
+
+export default function usePanoptes(subjectID, workflowID) {
+  const store = useContext(AppContext)
+
+  useEffect(() => {
+    store.subject.fetchSubject(subjectID)
+    store.workflow.fetchWorkflow(workflowID)
+
+    return () => {}
+  }, [workflowID, subjectID, store.workflow, store.subject])
+}

--- a/src/pages/SubjectPage.js
+++ b/src/pages/SubjectPage.js
@@ -1,12 +1,13 @@
-import { useContext, useEffect } from 'react'
+import { useContext } from 'react'
 import { Box, Heading, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import { useParams } from 'react-router'
 import styled from 'styled-components'
-import AppContext from 'stores'
 
 import AggregationsViewer from 'components/AggregationsViewer'
 import SubjectViewer from 'components/SubjectViewer'
+import { useCaesar, usePanoptes } from 'hooks'
+import AppContext from 'stores'
 
 const OverflowBox = styled(Box)`
   overflow: auto;
@@ -15,19 +16,8 @@ const OverflowBox = styled(Box)`
 function SubjectPage () {
   const store = useContext(AppContext)
   const { subjectId, workflowId } = useParams()
-  
-  useEffect(() => {
-    // Fetch Subject!
-    store.subject.fetchSubject(subjectId)
-    
-    // Fetch Workflow, and Aggregations!
-    // Please do this in order because aggregations don't make sense without a workflow.
-    store.workflow.fetchWorkflow(workflowId).then(() => {
-      store.aggregations.fetchAggregations(workflowId, subjectId)
-    })
-    
-    return () => {}
-  }, [workflowId, subjectId, store.workflow, store.subject, store.aggregations])
+  usePanoptes(subjectId, workflowId)
+  useCaesar(subjectId, workflowId)
   
   return (
     <Box>

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -55,16 +55,8 @@ const AggregationsStore = types.model('AggregationsStore', {
       const taskId = store.workflow.taskId
       const page = store.subject.page
 
-      switch (selectedTaskType) {
-        case 'drawing':
-          self.extractData_drawing(taskId, page, 0)
-          break
-        case 'single':
-          self.extractData_single(taskId)
-          break
-        default:
-          break
-      }
+      const extractData = self[`extractData_${selectedTaskType}`]
+      extractData?.(taskId, page, 0)
     } catch (error) {
       console.error('ERROR in AggregationsStore.extractData():', error)
     }

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -1,7 +1,5 @@
-import { flow, getRoot, types } from 'mobx-state-tree'
-import { request, gql } from 'graphql-request'
+import { getRoot, types } from 'mobx-state-tree'
 import ASYNC_STATES from 'helpers/asyncStates'
-import { config } from 'config'
 
 const Point = types.model('Point', {
   x: types.number,
@@ -45,40 +43,6 @@ const AggregationsStore = types.model('AggregationsStore', {
     self.stats.numExtractPoints = numExtractPoints || 0
     self.stats.numReductionPoints = numReductionPoints || 0
   },
-  
-  fetchAggregations: flow (function * fetchAggregations (workflowId, subjectId) {
-    self.asyncState = ASYNC_STATES.LOADING
-    
-    const store = getRoot(self)
-    const workflow = store.workflow.current
-    
-    try {
-      if (!workflow) throw Error('Can\'t fetch aggregations without a valid workflow')
-      
-      const query = gql`{
-        workflow(id: ${workflowId}) {
-          reductions(subjectId: ${subjectId}) {
-            data
-          }
-          extracts(subjectId: ${subjectId}) {
-            data
-          }
-        }
-      }`
-      
-      yield request(config.caesar, query).then((data) => {
-        self.setCurrent(data)
-        self.extractData()
-      })
-      
-      self.asyncState = ASYNC_STATES.READY
-    } catch (error) {
-      console.error(error)
-      self.error = error.message
-      self.current = undefined
-      self.asyncState = ASYNC_STATES.ERROR
-    }
-  }),
   
   extractData () {
     const store = getRoot(self)


### PR DESCRIPTION
- Add `useCaesar` and `usePanoptes` hooks to fetch aggregations, subjects and workflows.
- Move the Caesar graphQL query out of the store and into the `useCaesar` hook.