### PR TITLE
Add Caesar extractor and reducer keys

### DIFF
--- a/src/components/AggregationsViewer/AggregationsViewer.js
+++ b/src/components/AggregationsViewer/AggregationsViewer.js
@@ -37,85 +37,99 @@ function AggregationsViewer () {
   useEffect(() => {
     if (selectedTaskType === 'single') setExpand(true)
   }, [selectedTaskType])  // Only listen when selectedTaskType changes.
-  
-  if (store.workflow.asyncState === ASYNC_STATES.ERROR || store.aggregations.asyncState === ASYNC_STATES.ERROR) {
-    return (
-      <LargeMessageBox wide={false}>
-        {(store.workflow.asyncState === ASYNC_STATES.ERROR) &&
-          <>
-            <Text>ERROR: Could not fetch Workflow.</Text>
-            <Text>{store.workflow.error}</Text>
-          </>
-        }
-        {(store.aggregations.asyncState === ASYNC_STATES.ERROR) &&
-          <>
-            <Text>ERROR: Could not fetch Aggregations.</Text>
-            <Text>{store.aggregations.error}</Text>
-          </>
-        }
-      </LargeMessageBox>
-    )
-  }
-  
-  if (store.workflow.asyncState === ASYNC_STATES.LOADING || store.aggregations.asyncState === ASYNC_STATES.LOADING) {
-    return (
-      <LargeMessageBox wide={false}>
-        <Text>Loading Workflow and Aggregations...</Text>
-      </LargeMessageBox>
-    )
-  }
 
-  let AggregationType = null
+  const { IDLE, ERROR, LOADING, READY } = ASYNC_STATES
+  switch (store.aggregations.asyncState) {
+    case IDLE: {
+      return null
+    }
+    case ERROR: {
+      return (
+        <LargeMessageBox wide={false}>
+          {(store.workflow.asyncState === ASYNC_STATES.ERROR) &&
+            <>
+              <Text>ERROR: Could not fetch Workflow.</Text>
+              <Text>{store.workflow.error}</Text>
+            </>
+          }
+          {(store.aggregations.asyncState === ASYNC_STATES.ERROR) &&
+            <>
+              <Text>ERROR: Could not fetch Aggregations.</Text>
+              <Text>{store.aggregations.error}</Text>
+            </>
+          }
+        </LargeMessageBox>
+      )
+    }
+    case LOADING:
+    case READY: {
+      let AggregationType = null
+      if (!aggregationData) {
+        return (
+          <LargeMessageBox wide={false}>
+            <Text>Loading Workflow and Aggregations...</Text>
+          </LargeMessageBox>
+        )
+      }
   
-  switch (selectedTaskType) {
-    case 'drawing':
-      AggregationType = (
-        <DrawingTask
-          selectedTask={selectedTask}
-          stats={stats}
-        />)
-      break
+      switch (selectedTaskType) {
+        case 'drawing':
+          AggregationType = (
+            <DrawingTask
+              selectedTask={selectedTask}
+              stats={stats}
+            />)
+          break
         
-    case 'single':
-      AggregationType = (
-        <SingleTask
-          aggregationData={aggregationData}
-          expand={expand}
-          selectedTask={selectedTask}
-          stats={stats}
-        />)
-      break
+        case 'single':
+          AggregationType = (
+            <SingleTask
+              aggregationData={aggregationData}
+              expand={expand}
+              selectedTask={selectedTask}
+              stats={stats}
+            />)
+          break
     
-    default:
-      break
-  }
+        default:
+          break
+      }
 
-  if (!AggregationType) return null
+      if (!AggregationType) return null
   
-  return (
-    <CompactBox
-      background={{ color: colors['light-1'] }}
-      expand={expand}
-      round='xsmall'
-      pad='xsmall'
-    >
-      {(selectedTaskType === 'single') && (
-        <Box
-          direction='row'
+      return (
+        <CompactBox
+          background={{ color: colors['light-1'] }}
+          expand={expand}
+          round='xsmall'
+          pad='xsmall'
         >
-          <CompactButton
-            a11yTitle='Expand/collapse Aggregation panel'
-            icon={(expand)
-              ? <ContractIcon size='small' />
-              : <ExpandIcon size='small' />
-            }
-            onClick={() => { setExpand(!expand) }}
-          />
-        </Box>
-      )}
-      {AggregationType}
-    </CompactBox>
-  )
+          {(selectedTaskType === 'single') && (
+            <Box
+              direction='row'
+            >
+              <CompactButton
+                a11yTitle='Expand/collapse Aggregation panel'
+                icon={(expand)
+                  ? <ContractIcon size='small' />
+                  : <ExpandIcon size='small' />
+                }
+                onClick={() => { setExpand(!expand) }}
+              />
+            </Box>
+          )}
+          {AggregationType}
+        </CompactBox>
+      )
+    }
+    default: {
+      return (
+        <LargeMessageBox wide={false}>
+          <Text>Loading Workflow and Aggregations...</Text>
+        </LargeMessageBox>
+      )
+    }
+  }
 }
 
 export default observer(AggregationsViewer)

--- a/src/components/AggregationsViewer/AggregationsViewer.js
+++ b/src/components/AggregationsViewer/AggregationsViewer.js
@@ -29,9 +29,7 @@ function AggregationsViewer () {
   const colors = mergedTheme.global.colors
   const [expand, setExpand] = useState(false)
   
-  const selectedTask = store.workflow.selectedTask
-  const selectedTaskType = store.workflow.selectedTaskType
-  const selectedTaskIndex = store.workflow.selectedTaskIndex
+  const { selectedTask, selectedTaskType } = store.workflow
   const stats = store.aggregations.stats
   const aggregationData = store.aggregations.current && store.aggregations.current.workflow
   
@@ -83,7 +81,6 @@ function AggregationsViewer () {
         <SingleTask
           aggregationData={aggregationData}
           expand={expand}
-          selectedTaskIndex={selectedTaskIndex}
           selectedTask={selectedTask}
           stats={stats}
         />)

--- a/src/components/AggregationsViewer/components/SingleTask.js
+++ b/src/components/AggregationsViewer/components/SingleTask.js
@@ -37,7 +37,6 @@ const SingleTask = function ({
   aggregationData,
   expand,
   selectedTask,
-  selectedTaskIndex,
   stats,
 }) {
   if (!stats) return null
@@ -45,7 +44,8 @@ const SingleTask = function ({
   const { numClassifications } = stats
   const { reductions } = aggregationData
   
-  const reductionsData = reductions && reductions[selectedTaskIndex]?.data
+  const [reduction] = reductions
+  const reductionsData = reduction?.data
   
   if (!selectedTask || !answers || !reductions || !reductionsData) {
     return (

--- a/src/hooks/usePanoptes.js
+++ b/src/hooks/usePanoptes.js
@@ -10,4 +10,9 @@ export default function usePanoptes(subjectID, workflowID) {
 
     return () => {}
   }, [workflowID, subjectID, store.workflow, store.subject])
+
+  return {
+    subject: store.subject.current,
+    workflow: store.workflow.current
+  }
 }

--- a/src/pages/SubjectPage.js
+++ b/src/pages/SubjectPage.js
@@ -16,8 +16,8 @@ const OverflowBox = styled(Box)`
 function SubjectPage () {
   const store = useContext(AppContext)
   const { subjectId, workflowId } = useParams()
-  usePanoptes(subjectId, workflowId)
-  useCaesar(subjectId, workflowId)
+  const { subject, workflow } = usePanoptes(subjectId, workflowId)
+  useCaesar(subject.id, workflow.id)
   
   return (
     <Box>


### PR DESCRIPTION
Add extractor and reducer keys to Caesar queries, but only for workflows with more than one task. Assume that the Caesar key names will always match the task identifier eg. `init`, `T1`, `T2` etc.

Remove `selectedTaskIndex` from the task logic, since reductions will only be fetched for a single task now.

Closes #78.