### PR TITLE
Enable HTTPS for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Website: https://zoo-notes.zooniverse.org/
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-- `yarn start` starts the web app in development mode. Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+- `yarn start` starts the web app in development mode. Open [https://localhost:3000](https://localhost:3000) to view it in the browser.
 - `yarn eject` is a ONE-WAY operation that disassembles the React Script into its component bits. Maybe DON'T run this code, unless `react-script` is completely borked.
 
 ### External Dependencies

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "start": "export REACT_APP_HEAD_COMMIT=${HEAD_COMMIT:-$(git rev-parse --short HEAD)}; react-scripts start",
+    "start": "export REACT_APP_HEAD_COMMIT=${HEAD_COMMIT:-$(git rev-parse --short HEAD)}; HTTPS=true react-scripts start",
     "build": "export REACT_APP_HEAD_COMMIT=${HEAD_COMMIT:-$(git rev-parse --short HEAD)} CI=false; react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Turn on HTTPS for local development. I don't think the app uses Panoptes secure cookies at the moment, but this enables them if they are needed eg. to request private resources.