### PR TITLE
Automate data extraction in the Aggregations store

### DIFF
--- a/src/hooks/useCaesar.js
+++ b/src/hooks/useCaesar.js
@@ -61,8 +61,5 @@ export default function useCaesar(subjectID, workflowID) {
       asyncState: loadingState
     }
     applySnapshot(store.aggregations, newSnapshot)
-    if (loadingState === ASYNC_STATES.READY) {
-      store.aggregations.extractData()
-    }
   }, [data, error, loadingState, store.aggregations])
 }

--- a/src/hooks/useCaesar.js
+++ b/src/hooks/useCaesar.js
@@ -45,7 +45,8 @@ export default function useCaesar(subjectID, workflowID) {
   }
 
   const dataArgs = [subjectID, workflowID, extractorKey, reducerKey]
-  const { data, error } = useSWR( taskId ? dataArgs : null, fetchAggregations)
+  const dataReady = subjectID && taskId
+  const { data, error } = useSWR( dataReady ? dataArgs : null, fetchAggregations)
   if (error) {
     loadingState = ASYNC_STATES.ERROR
   }

--- a/src/stores/AggregationsStore.js
+++ b/src/stores/AggregationsStore.js
@@ -1,4 +1,4 @@
-import { getRoot, types } from 'mobx-state-tree'
+import { applySnapshot, getRoot, types } from 'mobx-state-tree'
 import ASYNC_STATES from 'helpers/asyncStates'
 
 const Point = types.model('Point', {
@@ -30,20 +30,6 @@ const AggregationsStore = types.model('AggregationsStore', {
     self.current = data
   },
   
-  setExtracts (data) {
-    self.extracts = data
-  },
-  
-  setReductions (data) {
-    self.reductions = data
-  },
-  
-  setStats ({ numClassifications, numExtractPoints, numReductionPoints }) {
-    self.stats.numClassifications = numClassifications || 0
-    self.stats.numExtractPoints = numExtractPoints || 0
-    self.stats.numReductionPoints = numReductionPoints || 0
-  },
-  
   extractData () {
     const store = getRoot(self)
     const workflow = store.workflow.current
@@ -66,15 +52,11 @@ const AggregationsStore = types.model('AggregationsStore', {
   extractData_single (taskId = 'T0') {
     try {
       const wf = self.current.workflow
-
-      self.setStats ({
-        numClassifications: (wf.extracts && wf.extracts.length) || 0,
-      })
+      const numClassifications = wf.extracts?.length || 0
+      applySnapshot(self.stats, { numClassifications })
     } catch (error) {
       console.error(error)
-      self.setStats ({
-        numClassifications: 0,
-      })
+      applySnapshot(self.stats, { numClassifications: 0 })
     }
   },
   
@@ -115,18 +97,18 @@ const AggregationsStore = types.model('AggregationsStore', {
         }
       })
 
-      self.setExtracts(extracts)
-      self.setReductions(reductions)
-      self.setStats ({
-        numClassifications: numClassifications,
+      applySnapshot(self.extracts, extracts)
+      applySnapshot(self.reductions, reductions)
+      applySnapshot(self.stats, {
+        numClassifications,
         numExtractPoints: extracts.length,
         numReductionPoints: reductions.length,
       })
     } catch (error) {
       console.error(error)
-      self.setExtracts([])
-      self.setReductions([])
-      self.setStats ({
+      applySnapshot(self.extracts, [])
+      applySnapshot(self.reductions, [])
+      applySnapshot(self.stats, {
         numClassifications: 0,
         numExtractPoints: 0,
         numReductionPoints: 0,

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -1,5 +1,6 @@
 import { autorun } from 'mobx'
 import { addDisposer, types } from 'mobx-state-tree'
+import ASYNC_STATES from 'helpers/asyncStates'
 import { AggregationsStore } from './AggregationsStore'
 import { ImageStore } from './ImageStore'
 import { SubjectStore } from './SubjectStore'
@@ -11,12 +12,20 @@ const AppStore = types.model('AppStore', {
   image: types.optional(ImageStore, () => ImageStore.create({})),
   subject: types.optional(SubjectStore, () => SubjectStore.create({})),
   viewer: types.optional(ViewerStore, () => ViewerStore.create({})),
-  workflow: types.optional(WorkflowStore, () => WorkflowStore.create({}))
-}).actions(self => {
+  workflow: types.optional(WorkflowStore, () => WorkflowStore.create({})),
+})
+.views(self => ({
+  get isReady() {
+    return (
+      self.subject.asyncState === ASYNC_STATES.READY &&
+      self.workflow.asyncState === ASYNC_STATES.READY &&
+      self.aggregations.asyncState === ASYNC_STATES.READY
+    )
+  }
+}))
+.actions(self => {
   function _onDataReady() {
-    const workflow = self.workflow.current
-    const data = self.aggregations.current
-    if (data && workflow) {
+    if (self.isReady) {
       self.aggregations.extractData()
     }
   }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -1,4 +1,5 @@
-import { types } from 'mobx-state-tree'
+import { autorun } from 'mobx'
+import { addDisposer, types } from 'mobx-state-tree'
 import { AggregationsStore } from './AggregationsStore'
 import { ImageStore } from './ImageStore'
 import { SubjectStore } from './SubjectStore'
@@ -10,7 +11,22 @@ const AppStore = types.model('AppStore', {
   image: types.optional(ImageStore, () => ImageStore.create({})),
   subject: types.optional(SubjectStore, () => SubjectStore.create({})),
   viewer: types.optional(ViewerStore, () => ViewerStore.create({})),
-  workflow: types.optional(WorkflowStore, () => WorkflowStore.create({})),
+  workflow: types.optional(WorkflowStore, () => WorkflowStore.create({}))
+}).actions(self => {
+  function _onDataReady() {
+    const workflow = self.workflow.current
+    const data = self.aggregations.current
+    if (data && workflow) {
+      self.aggregations.extractData()
+    }
+  }
+
+  return {
+    afterCreate() {
+      const dataDisposer = autorun(_onDataReady)
+      addDisposer(self, dataDisposer)
+    }
+  }
 })
 
 export { AppStore }


### PR DESCRIPTION
Add an `autorun` reaction to the root store, which observes the subject, workflow and downloaded Caesar data, and runs `aggregations.extractData()` when all three are ready.
