### PR TITLE
Wrap store updates in a useEffect hook

### DIFF
--- a/src/hooks/useCaesar.js
+++ b/src/hooks/useCaesar.js
@@ -45,17 +45,19 @@ export default function useCaesar(subjectID, workflowID) {
     loadData(subjectID, workflowID)
   }, [subjectID, workflowID])
 
-  if (loadingState === ASYNC_STATES.READY) {
-    applySnapshot(store.aggregations, {
-      current: data,
-      asyncState: loadingState
-    })
-    store.aggregations.extractData()
-  }
-  if (loadingState === ASYNC_STATES.ERROR) {
-    applySnapshot(store.aggregations, {
-      error,
-      asyncState: loadingState
-    })
-  }
+  useEffect(() => {
+    if (loadingState === ASYNC_STATES.READY) {
+      applySnapshot(store.aggregations, {
+        current: data,
+        asyncState: loadingState
+      })
+      store.aggregations.extractData()
+    }
+    if (loadingState === ASYNC_STATES.ERROR) {
+      applySnapshot(store.aggregations, {
+        error,
+        asyncState: loadingState
+      })
+    }
+  }, [data, error, loadingState, store.aggregations])
 }


### PR DESCRIPTION
Fixes a React render error by wrapping aggregations store updates inside a `useEffect` hook, so that they run outside the main render cycle.

Closes #92.