### PR TITLE
Improved data fetching

### DIFF
--- a/src/hooks/useCaesar.js
+++ b/src/hooks/useCaesar.js
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from 'react'
 import { request, gql } from 'graphql-request'
-import { applySnapshot } from 'mobx-state-tree'
+import { applySnapshot, getSnapshot } from 'mobx-state-tree'
 import useSWR from 'swr'
 import ASYNC_STATES from 'helpers/asyncStates'
 import { config } from 'config'
@@ -55,8 +55,10 @@ export default function useCaesar(subjectID, workflowID) {
   }
 
   useEffect(() => {
+    const snapshot = getSnapshot(store.aggregations)
     const current = data || store.aggregations.current
     const newSnapshot = {
+      ...snapshot,
       current,
       error,
       asyncState: loadingState

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -25,7 +25,7 @@ const AppStore = types.model('AppStore', {
 }))
 .actions(self => {
   function _onDataReady() {
-    if (self.isReady) {
+    if (self.isReady && self.workflow.taskId) {
       self.aggregations.extractData()
     }
   }


### PR DESCRIPTION
- run `extractData` when the selected task changes.
- merge snapshots when updating aggregations with new data from Caesar.